### PR TITLE
Added instructor view to open/close a rapid-response-enabled problem

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -356,3 +356,6 @@ pip-selfcheck.json
 
 # Pycharm
 .idea/
+
+# Pytest
+.pytest_cache/

--- a/README.md
+++ b/README.md
@@ -1,2 +1,21 @@
 # rapid-response-xblock
-a django app plug-in for edx-platform 
+A django app plugin for edx-platform
+
+## Database Migrations
+
+If you make any model changes in this project, new migrations can 
+be created as follows:
+
+- Run `edx-platform` with this package listed as a requirement. One
+   way to do this is to mount this repo directory to devstack and in
+   `/requirements/private.txt` add that path:
+   ``` 
+   -e /path/to/rapid-response-xblock
+   ```
+- Run the `makemigrations` Django management command within devstack:
+   ```
+   python manage.py lms makemigrations rapid_response_xblock --settings=devstack_docker
+   ```
+   If your `rapid-response-xblock` repo is mounted to the devstack container,
+   you'll see the migrations directory and files added to your local repo, ready
+   to be added and committed in Git.

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -1,0 +1,139 @@
+"""Rapid-response functionality"""
+
+import logging
+from functools import wraps
+from collections import namedtuple
+import pkg_resources
+from django.db import transaction
+from django.template import Context, Template
+from web_fragments.fragment import Fragment
+from webob.response import Response
+
+from xblock.core import XBlock, XBlockAside
+from xmodule.x_module import XModuleMixin
+
+from rapid_response_xblock.models import RapidResponseBlockStatus
+
+log = logging.getLogger(__name__)
+
+
+def get_resource_bytes(path):
+    """
+    Helper method to get the unicode contents of a resource in this repo.
+
+    Args:
+        path (str): The path of the resource
+
+    Returns:
+        unicode: The unicode contents of the resource at the given path
+    """
+    resource_contents = pkg_resources.resource_string(__name__, path)
+    return unicode(resource_contents)
+
+
+def render_template(template_path, context=None):
+    """
+    Evaluate a template by resource path, applying the provided context.
+    """
+    context = context or {}
+    template_str = get_resource_bytes(template_path)
+    template = Template(template_str)
+    return template.render(Context(context))
+
+
+# TODO: Decide on how we're going to enable specific blocks for rapid response
+def is_block_rapid_enabled(block):
+    """
+    Returns True if the given block is enabled for rapid response
+    """
+    return '[RAPID]' in block.display_name
+
+
+def staff_only_handler_method(handler_method):
+    """
+    Wrapper that ensures a handler method is enabled for staff users only
+    """
+    @wraps(handler_method)
+    def wrapper(aside_instance, *args, **kwargs):  # pylint: disable=missing-docstring
+        if not aside_instance.is_staff():
+            return Response(
+                status=403,
+                json_body="Unauthorized (staff only)"
+            )
+        return handler_method(aside_instance, *args, **kwargs)
+    return wrapper
+
+
+TemplateContext = namedtuple('TemplateContext', ['is_staff', 'is_open'])
+
+
+class RapidResponseAside(XBlockAside, XModuleMixin):
+    """
+    XBlock aside that enables rapid-response functionality for an XBlock
+    """
+    @XBlockAside.aside_for('student_view')
+    def student_view_aside(self, block, context=None):  # pylint: disable=unused-argument
+        """
+        Renders the aside contents for the student view
+        """
+        fragment = Fragment(u'')
+        if not is_block_rapid_enabled(block):
+            return fragment
+        fragment.add_content(
+            render_template(
+                "static/html/rapid.html",
+                self.get_initial_template_context()
+            )
+        )
+        fragment.add_css(get_resource_bytes("static/css/rapid.css"))
+        fragment.add_javascript(get_resource_bytes("static/js/src/rapid.js"))
+        fragment.initialize_js("RapidResponseAsideInit")
+        return fragment
+
+    @XBlock.handler
+    @staff_only_handler_method
+    def toggle_block_open_status(self, request=None, suffix=None):  # pylint: disable=unused-argument
+        """
+        Toggles the open/closed status for the rapid-response-enabled block
+        """
+        with transaction.atomic():
+            status, _ = RapidResponseBlockStatus.objects.get_or_create(
+                usage_key=self.wrapped_block_usage_key,
+                course_key=self.course_key
+            )
+            status.open = not bool(status.open)
+            status.save()
+        return Response(
+            json_body=TemplateContext(
+                is_open=status.open,
+                is_staff=self.is_staff()
+            )._asdict()
+        )
+
+    @property
+    def wrapped_block_usage_key(self):
+        """The usage_key for the block that is being wrapped by this aside"""
+        return self.scope_ids.usage_id.usage_key
+
+    @property
+    def course_key(self):
+        """The course_key for this aside"""
+        return self.scope_ids.usage_id.course_key
+
+    def is_staff(self):
+        """Returns True if the user has staff permissions"""
+        return getattr(self.runtime, 'user_is_staff', False)
+
+    def get_initial_template_context(self):
+        """
+        Gets the template context object for the aside when it's first loaded
+        """
+        status = RapidResponseBlockStatus.objects.filter(
+            usage_key=self.wrapped_block_usage_key,
+            course_key=self.course_key
+        ).first()
+        is_open = False if not status else status.open
+        return TemplateContext(
+            is_open=is_open,
+            is_staff=self.is_staff()
+        )._asdict()

--- a/rapid_response_xblock/func.py
+++ b/rapid_response_xblock/func.py
@@ -1,8 +1,0 @@
-"""
-Testing functions
-"""
-
-
-def add(num1, num2):
-    """Add two numbers"""
-    return num1 + num2

--- a/rapid_response_xblock/migrations/0002_block_status.py
+++ b/rapid_response_xblock/migrations/0002_block_status.py
@@ -1,0 +1,24 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import opaque_keys.edx.django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rapid_response_xblock', '0001_initial'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RapidResponseBlockStatus',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('usage_key', opaque_keys.edx.django.models.UsageKeyField(max_length=255, db_index=True)),
+                ('open', models.BooleanField(default=False)),
+                ('course_key', opaque_keys.edx.django.models.CourseKeyField(max_length=255, db_index=True)),
+            ],
+        ),
+    ]

--- a/rapid_response_xblock/models.py
+++ b/rapid_response_xblock/models.py
@@ -1,5 +1,5 @@
 """
-Models for storing rapid response grades
+Rapid Response block models
 """
 from __future__ import unicode_literals
 
@@ -39,5 +39,25 @@ class RapidResponseSubmission(TimeStampedModel):
                 user=self.user,
                 problem_id=self.problem_id,
                 answer_id=self.answer_id,
+            )
+        )
+
+
+@python_2_unicode_compatible
+class RapidResponseBlockStatus(models.Model):
+    """
+    Indicates whether a rapid-response-enabled XBlock for a given course is "open" or not
+    ("open" = set to collect student responses for the block in real time)
+    """
+    usage_key = UsageKeyField(max_length=255, db_index=True)
+    course_key = CourseKeyField(max_length=255, db_index=True)
+    open = models.BooleanField(default=False, null=False)
+
+    def __str__(self):
+        return (
+            "open={open} usage_key={usage_key} course_key={course_key}".format(
+                open=self.open,
+                usage_key=self.usage_key,
+                course_key=self.course_key
             )
         )

--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -1,0 +1,5 @@
+button.problem-status-toggle:hover {
+    background-color: #065683;
+    background-image: none;
+    box-shadow: none;
+}

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -1,0 +1,14 @@
+<div class="rapid-response-block" data-staff="{{ is_staff }}" data-open="{{ is_open }}">
+  <div id="rapid-response-content">
+  </div>
+
+  <script type="text/template" id="rapid-response-toggle-tmpl">
+    <% if (is_staff) { %>
+      <p>
+        <button class="btn btn-brand problem-status-toggle">
+          <%= is_open ? "Close" : "Open" %> Problem For Live Responses
+        </button>
+      </p>
+    <% } %>
+  </script>
+</div>

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -1,0 +1,45 @@
+(function($, _) {
+  'use strict';
+  function RapidResponseAsideView(runtime, element) {
+    var toggleStatusUrl = runtime.handlerUrl(element, 'toggle_block_open_status');
+    var $element = $(element);
+
+    var rapidTopLevelSel = '.rapid-response-block';
+    var rapidBlockContentSel = '#rapid-response-content';
+    var toggleTemplate = _.template($(element).find("#rapid-response-toggle-tmpl").text());
+
+    function render(state) {
+      // Render template
+      var $rapidBlockContent = $element.find(rapidBlockContentSel);
+      $rapidBlockContent.html(toggleTemplate(state));
+
+      $rapidBlockContent.find('.problem-status-toggle').click(function(e) {
+        $.get(toggleStatusUrl).then(
+          function(state) {
+            render(state);
+          }
+        ).fail(
+          function () {
+            console.log("toggle data FAILED [" + toggleStatusUrl + "]");
+          }
+        );
+      });
+    }
+
+    $(function($) { // onLoad
+      var block = $element.find(rapidTopLevelSel);
+      var isOpen = block.attr('data-open') === 'True';
+      var isStaff = block.attr('data-staff') === 'True';
+      render({
+        is_open: isOpen,
+        is_staff: isStaff
+      });
+    });
+  }
+
+  function initializeRapidResponseAside(runtime, element) {
+    return new RapidResponseAsideView(runtime, element);
+  }
+
+  window.RapidResponseAsideInit = initializeRapidResponseAside;
+}($, _));

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,20 @@
 """Setup for rapid-response XBlock."""
 
+import os
 from setuptools import setup, find_packages
 
 import rapid_response_xblock
+
+
+def package_data(pkg, root_list):
+    """Generic function to find package_data for `pkg` under `root`."""
+    data = []
+    for root in root_list:
+        for dirname, _, files in os.walk(os.path.join(pkg, root)):
+            for fname in files:
+                data.append(os.path.relpath(os.path.join(dirname, fname), pkg))
+
+    return {pkg: data}
 
 
 setup(
@@ -13,14 +25,21 @@ setup(
     url="https://github.com/mitodl/rapid-response-xblock",
     author="MITx",
     zip_safe=False,
+    install_requires=[
+        'django>=1.8,<=1.11',
+        'XBlock',
+        'xblock-utils',
+        'edx-opaque-keys'
+    ],
     packages=find_packages(),
+    package_data=package_data("rapid_response_xblock", ["static"]),
     include_package_data=True,
-    install_requires=['django>=1.8,<=1.11'],
     entry_points={
-        "lms.djangoapp": [
-            "rapid_response_xblock = "
-            "rapid_response_xblock.apps:RapidResponseAppConfig"
+        'xblock_asides.v1': [
+            'rapid_response_xblock = rapid_response_xblock.block:RapidResponseAside',
         ],
-        "cms.djangoapp": []
+        'lms.djangoapp': [
+            'rapid_response_xblock = rapid_response_xblock.apps:RapidResponseAppConfig'
+        ],
     }
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,22 @@
+"""Pytest config"""
+import logging
+
+
+def pytest_addoption(parser):
+    """Pytest hook that adds command line options"""
+    parser.addoption(
+        "--disable-logging", action="store_true", default=False,
+        help="Disable all logging during test run"
+    )
+    parser.addoption(
+        "--error-log-only", action="store_true", default=False,
+        help="Disable all logging output below 'error' level during test run"
+    )
+
+
+def pytest_configure(config):
+    """Pytest hook that runs after command line options have been parsed"""
+    if config.getoption("--disable-logging"):
+        logging.disable(logging.CRITICAL)
+    elif config.getoption("--error-log-only"):
+        logging.disable(logging.WARNING)

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -1,0 +1,69 @@
+"""Tests for the rapid-response aside logic"""
+from ddt import data, ddt, unpack
+from mock import Mock, patch
+
+from opaque_keys.edx.keys import UsageKey
+
+from rapid_response_xblock.block import RapidResponseAside
+from rapid_response_xblock.models import RapidResponseBlockStatus
+from tests.utils import RuntimeEnabledTestCase, make_scope_ids
+
+
+@ddt
+class RapidResponseAsideTests(RuntimeEnabledTestCase):
+    """Tests for RapidResponseAside logic"""
+    def setUp(self):
+        super(RapidResponseAsideTests, self).setUp()
+        self.aside_usage_key = UsageKey.from_string(
+            "aside-usage-v2:block-v1$:ReplaceStatic+ReplaceStatic+2018_T1+type@problem+block"
+            "@b9dca79886ef481dbade98a50de54673::rapid_response_xblock"
+        )
+        self.scope_ids = make_scope_ids(self.runtime, self.aside_usage_key)
+        self.aside_instance = RapidResponseAside(
+            scope_ids=self.scope_ids,
+            runtime=self.runtime
+        )
+
+    @data(*[
+        ['[RAPID]', True],
+        ['block without rapid response', False],
+    ])
+    @unpack
+    def test_student_view(self, display_name, should_render_aside):
+        """
+        Test that the aside student view returns a fragment if the block is
+        rapid-response-enabled
+        """
+        mock_xblock = Mock(display_name=display_name)
+        fragment = self.aside_instance.student_view_aside(mock_xblock)
+        # If the block is enabled for rapid response, it should return a fragment with
+        # non-empty content and should specify a JS initialization function
+        assert bool(fragment.content) is should_render_aside
+        assert (fragment.js_init_fn == 'RapidResponseAsideInit') is should_render_aside
+
+    def test_toggle_block_open(self):
+        """Test that toggle_block_open_status changes the status of a rapid response block"""
+        block_status = RapidResponseBlockStatus.objects.create(
+            usage_key=self.aside_instance.wrapped_block_usage_key,
+            course_key=self.aside_instance.course_key
+        )
+        assert block_status.open is False
+
+        self.aside_instance.toggle_block_open_status(Mock())
+        block_status.refresh_from_db()
+        assert block_status.open is True
+
+        self.aside_instance.toggle_block_open_status(Mock())
+        block_status.refresh_from_db()
+        assert block_status.open is False
+
+    @data(*[
+        [True, 200],
+        [False, 403]
+    ])
+    @unpack
+    def test_toggle_block_open_staff_only(self, is_staff, expected_status):
+        """Test that toggle_block_open_status is only enabled for staff"""
+        with patch.object(self.aside_instance, 'is_staff', return_value=is_staff):
+            resp = self.aside_instance.toggle_block_open_status()
+        assert resp.status_code == expected_status

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,94 @@
+"""Utility functions and classes for the rapid response test suite"""
+import os
+import shutil
+import tempfile
+from mock import Mock
+
+from django.http.request import HttpRequest
+
+from courseware.module_render import (
+    get_module_system_for_user,
+    make_track_function,
+)
+from courseware.tests.factories import StaffFactory
+from student.tests.factories import AdminFactory
+from xblock.fields import ScopeIds
+from xmodule.modulestore.django import modulestore
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import ItemFactory
+from xmodule.modulestore.xml_importer import import_course_from_xml
+
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
+
+
+def make_scope_ids(runtime, usage_key):
+    """
+    Make scope ids
+    """
+    block_type = 'fake'
+    def_id = runtime.id_generator.create_definition(block_type)
+    return ScopeIds(
+        'user', block_type, def_id, usage_key
+    )
+
+
+class RuntimeEnabledTestCase(ModuleStoreTestCase):
+    """
+    Test class that sets up a course, instructor, runtime, and other
+    commonly-needed objects for testing XBlocks
+    """
+    def setUp(self):
+        super(RuntimeEnabledTestCase, self).setUp()
+        self.track_function = make_track_function(HttpRequest())
+        self.student_data = Mock()
+        self.course = self.import_test_course()
+        self.descriptor = ItemFactory(category="pure", parent=self.course)
+        self.course_id = self.course.id
+        self.instructor = StaffFactory.create(course_key=self.course_id)
+        self.runtime = self.make_runtime()
+        self.runtime.error_tracker = None
+        self.staff = AdminFactory.create()
+        self.course.bind_for_student(self.runtime, self.instructor)
+
+    def make_runtime(self, **kwargs):
+        """
+        Make a runtime
+        """
+        runtime, _ = get_module_system_for_user(
+            user=self.instructor,
+            student_data=self.student_data,
+            descriptor=self.descriptor,
+            course_id=self.course.id,
+            track_function=self.track_function,
+            xqueue_callback_url_prefix=Mock(),
+            request_token=Mock(),
+            course=self.course,
+            wrap_xmodule_display=False,
+            **kwargs
+        )
+        runtime.get_policy = lambda _: {}
+
+        return runtime
+
+    def import_test_course(self):
+        """
+        Import the test course with the sga unit
+        """
+        # adapted from edx-platform/cms/djangoapps/contentstore/
+        # management/commands/tests/test_cleanup_assets.py
+        input_dir = os.path.join(BASE_DIR, "..", "test_data")
+
+        temp_dir = tempfile.mkdtemp()
+        self.addCleanup(lambda: shutil.rmtree(temp_dir))
+
+        xml_dir = os.path.join(temp_dir, "xml")
+        shutil.copytree(input_dir, xml_dir)
+
+        store = modulestore()
+        courses = import_course_from_xml(
+            store,
+            'sga_user',
+            xml_dir,
+        )
+        return courses[0]


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #10 

#### What's this PR do?
Adds an instructor view to a rapid-response-enabled xblock where a user can set the problem to be open or closed

#### How should this be manually tested?
- Start LMS and pip install this package
- Make these changes to the corresponding devstack config files:
    - `lms.env.json`: 
        `"ADDL_INSTALLED_APPS": ["rapid_response_xblock"]`
    - `cms.env.json`: 
        `"ADDL_INSTALLED_APPS": ["rapid_response_xblock"]`
        `"ALLOW_ALL_ADVANCED_COMPONENTS": true`
- Run migrations (this PR adds a new model)
- In Studio, rename some problem to have `[RAPID]` in the title (this will be our initial hacky way to set an xblock to be rapid-response-enabled)
- In LMS, navigate to that block as a staff user. You should see a button that says "Open/Close Problem for Live Responses"
- When you click that button, the text should toggle between "Open" and "Close"

#### Where should the reviewer start?
`rapid_response_xblock/block.py`

#### Any background context you want to provide?
There are a couple hacks in here, both flagged with `TODO` comments

#### Screenshots (if appropriate)
![ss 2018-02-22 at 15 53 13](https://user-images.githubusercontent.com/14932219/36563570-8a8f57c2-17e8-11e8-8850-2b79ad1c9245.png)

