### PR TITLE
Add REST API for responses

### DIFF
--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -144,7 +144,7 @@ class RapidResponseAside(XBlockAside):
     @staff_only_handler_method
     def responses(self, request=None, suffix=None):  # pylint: disable=unused-argument
         """
-        REST API for response information
+        Returns student responses for rapid-response-enabled block
         """
         status = RapidResponseBlockStatus.objects.filter(
             usage_key=self.wrapped_block_usage_key,

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -11,7 +11,10 @@ from webob.response import Response
 
 from xblock.core import XBlock, XBlockAside
 
-from rapid_response_xblock.models import RapidResponseBlockStatus
+from rapid_response_xblock.models import (
+    RapidResponseBlockStatus,
+    RapidResponseSubmission,
+)
 
 log = logging.getLogger(__name__)
 
@@ -136,3 +139,25 @@ class RapidResponseAside(XBlockAside):
             is_open=is_open,
             is_staff=self.is_staff()
         )._asdict()
+
+    @XBlock.handler
+    @staff_only_handler_method
+    def responses(self, request=None, suffix=None):  # pylint: disable=unused-argument
+        """
+        REST API for response information
+        """
+        status = RapidResponseBlockStatus.objects.filter(
+            usage_key=self.wrapped_block_usage_key,
+            course_key=self.course_key
+        ).first()
+        is_open = False if not status else status.open
+        responses = list(
+            RapidResponseSubmission.objects.filter(
+                problem_id=self.wrapped_block_usage_key,
+                course_id=self.course_key,
+            ).values('id', 'answer_id', 'answer_text')
+        )
+        return Response(json_body={
+            'is_open': is_open,
+            'responses': responses,
+        })

--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -3,3 +3,7 @@ button.problem-status-toggle:hover {
     background-image: none;
     box-shadow: none;
 }
+
+#rapid-response-content td, #rapid-response-content th {
+    border: 1px solid black;
+}

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -1,8 +1,6 @@
 <div class="rapid-response-block" data-staff="{{ is_staff }}" data-open="{{ is_open }}">
   <div id="rapid-response-content">
   </div>
-  <div id="rapid-response-data">
-  </div>
 
   <script type="text/template" id="rapid-response-toggle-tmpl">
     <% if (is_staff) { %>

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -1,6 +1,8 @@
 <div class="rapid-response-block" data-staff="{{ is_staff }}" data-open="{{ is_open }}">
   <div id="rapid-response-content">
   </div>
+  <div id="rapid-response-data">
+  </div>
 
   <script type="text/template" id="rapid-response-toggle-tmpl">
     <% if (is_staff) { %>
@@ -9,6 +11,26 @@
           <%= is_open ? "Close" : "Open" %> Problem For Live Responses
         </button>
       </p>
+      <% if (responses) { %>
+        <table>
+          <tr>
+            <th>Primary key</th>
+            <th>Answer id</th>
+            <th>Answer text</th>
+          </tr>
+          <% _.forEach(responses, function(response) { %>
+          <tr>
+            <td><%= response.id %></td>
+            <td><%= response.answer_id %></td>
+            <td><%= response.answer_text %></td>
+          </tr>
+          <% }) %>
+        </table>
+      <% } else { %>
+        <p>
+          No responses to display
+        </p>
+      <% } %>
     <% } %>
   </script>
 </div>

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -58,15 +58,13 @@
 
     $(function($) { // onLoad
       var block = $element.find(rapidTopLevelSel);
-      var isOpen = block.attr('data-open') === 'True';
-      var isStaff = block.attr('data-staff') === 'True';
       Object.assign(state, {
-        is_open: isOpen,
-        is_staff: isStaff
+        is_open: block.attr('data-open') === 'True',
+        is_staff: block.attr('data-staff') === 'True'
       });
       render();
 
-      if (isStaff) {
+      if (state.is_staff) {
         pollForResponses();
       }
     });

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -1,5 +1,9 @@
 (function($, _) {
   'use strict';
+
+  // time between polls of responses API
+  var POLLING_MILLIS = 3000;
+
   function RapidResponseAsideView(runtime, element) {
     var toggleStatusUrl = runtime.handlerUrl(element, 'toggle_block_open_status');
     var responsesUrl = runtime.handlerUrl(element, 'responses');
@@ -42,7 +46,7 @@
         state = Object.assign({}, state, newState);
         render();
         if (state.is_open) {
-          setTimeout(pollForResponses, 3000);
+          setTimeout(pollForResponses, POLLING_MILLIS);
         }
       }).fail(function () {
         // TODO: try again?
@@ -58,7 +62,9 @@
       state.is_staff = isStaff;
       render();
 
-      pollForResponses();
+      if (isStaff) {
+        pollForResponses();
+      }
     });
   }
 

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -60,8 +60,10 @@
       var block = $element.find(rapidTopLevelSel);
       var isOpen = block.attr('data-open') === 'True';
       var isStaff = block.attr('data-staff') === 'True';
-      state.is_open = isOpen;
-      state.is_staff = isStaff;
+      Object.assign(state, {
+        is_open: isOpen,
+        is_staff: isStaff
+      });
       render();
 
       if (isStaff) {

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -2,21 +2,32 @@
   'use strict';
   function RapidResponseAsideView(runtime, element) {
     var toggleStatusUrl = runtime.handlerUrl(element, 'toggle_block_open_status');
+    var responsesUrl = runtime.handlerUrl(element, 'responses');
     var $element = $(element);
 
     var rapidTopLevelSel = '.rapid-response-block';
     var rapidBlockContentSel = '#rapid-response-content';
     var toggleTemplate = _.template($(element).find("#rapid-response-toggle-tmpl").text());
 
-    function render(state) {
+    // default values
+    var state = {
+      is_open: false,
+      is_staff: false,
+      responses: []
+    };
+
+    function render() {
       // Render template
       var $rapidBlockContent = $element.find(rapidBlockContentSel);
       $rapidBlockContent.html(toggleTemplate(state));
 
       $rapidBlockContent.find('.problem-status-toggle').click(function(e) {
         $.get(toggleStatusUrl).then(
-          function(state) {
-            render(state);
+          function(newState) {
+            state = Object.assign({}, state, newState);
+            render();
+
+            pollForResponses();
           }
         ).fail(
           function () {
@@ -26,14 +37,28 @@
       });
     }
 
+    function pollForResponses() {
+      $.get(responsesUrl).then(function(newState) {
+        state = Object.assign({}, state, newState);
+        render();
+        if (state.is_open) {
+          setTimeout(pollForResponses, 3000);
+        }
+      }).fail(function () {
+        // TODO: try again?
+        console.error("Error retrieving response data");
+      });
+    }
+
     $(function($) { // onLoad
       var block = $element.find(rapidTopLevelSel);
       var isOpen = block.attr('data-open') === 'True';
       var isStaff = block.attr('data-staff') === 'True';
-      render({
-        is_open: isOpen,
-        is_staff: isStaff
-      });
+      state.is_open = isOpen;
+      state.is_staff = isStaff;
+      render();
+
+      pollForResponses();
     });
   }
 

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -31,7 +31,9 @@
             state = Object.assign({}, state, newState);
             render();
 
-            pollForResponses();
+            if (state.is_open) {
+              pollForResponses();
+            }
           }
         ).fail(
           function () {

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,12 @@
 """Pytest config"""
+import json
 import logging
+import os
+
+import pytest
+
+
+BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
 def pytest_addoption(parser):
@@ -20,3 +27,11 @@ def pytest_configure(config):
         logging.disable(logging.CRITICAL)
     elif config.getoption("--error-log-only"):
         logging.disable(logging.WARNING)
+
+
+@pytest.fixture(scope="function")
+def example_event(request):
+    """An example real event captured previously"""
+    with open(os.path.join(BASE_DIR, "..", "test_data", "example_event.json")) as f:
+        request.cls.example_event = json.load(f)
+        yield

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -1,27 +1,22 @@
 """Tests for the rapid-response aside logic"""
 from ddt import data, ddt, unpack
 from mock import Mock, patch
-from random import choice
 
 from django.contrib.auth.models import User
 from opaque_keys.edx.keys import UsageKey
-from opaque_keys.edx.locator import CourseLocator
 import pytest
 
 from rapid_response_xblock.block import RapidResponseAside
-from rapid_response_xblock.logger import SubmissionRecorder
 from rapid_response_xblock.models import (
     RapidResponseBlockStatus,
     RapidResponseSubmission,
 )
 from tests.utils import (
-    combine_dicts,
     make_scope_ids,
     RuntimeEnabledTestCase,
 )
 
 
-# pylint: disable=no-member
 @ddt
 class RapidResponseAsideTests(RuntimeEnabledTestCase):
     """Tests for RapidResponseAside logic"""

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -13,7 +13,7 @@ from rapid_response_xblock.models import (
     RapidResponseSubmission,
 )
 from tests.utils import (
-    dict_with,
+    combine_dicts,
     make_scope_ids,
     RuntimeEnabledTestCase,
 )
@@ -113,9 +113,9 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         Test that the responses API will show recorded events during the open period
         """
         event = self.example_event
-        event_before = dict_with(event, {'test_data': 'before'})
-        event_during = dict_with(event, {'test_data': 'during'})
-        event_after = dict_with(event, {'test_data': 'after'})
+        event_before = combine_dicts(event, {'test_data': 'before'})
+        event_during = combine_dicts(event, {'test_data': 'during'})
+        event_after = combine_dicts(event, {'test_data': 'after'})
 
         problem_id = UsageKey.from_string(event['event']['problem_id'])
         course_id = CourseLocator.from_string(event['context']['course_id'])

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -113,7 +113,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         course_id = self.aside_instance.course_key
 
         submissions = []
-        for n in range(50):
+        for n in range(5):
             username = 'user_{}'.format(n)
             email = 'user{}@email.com'.format(n)
             answer_id = 'answer_{}'.format(n)

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -3,12 +3,23 @@ from ddt import data, ddt, unpack
 from mock import Mock, patch
 
 from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.locator import CourseLocator
+import pytest
 
 from rapid_response_xblock.block import RapidResponseAside
-from rapid_response_xblock.models import RapidResponseBlockStatus
-from tests.utils import RuntimeEnabledTestCase, make_scope_ids
+from rapid_response_xblock.logger import SubmissionRecorder
+from rapid_response_xblock.models import (
+    RapidResponseBlockStatus,
+    RapidResponseSubmission,
+)
+from tests.utils import (
+    dict_with,
+    make_scope_ids,
+    RuntimeEnabledTestCase,
+)
 
 
+# pylint: disable=no-member
 @ddt
 class RapidResponseAsideTests(RuntimeEnabledTestCase):
     """Tests for RapidResponseAside logic"""
@@ -16,7 +27,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         super(RapidResponseAsideTests, self).setUp()
         self.aside_usage_key = UsageKey.from_string(
             "aside-usage-v2:block-v1$:ReplaceStatic+ReplaceStatic+2018_T1+type@problem+block"
-            "@b9dca79886ef481dbade98a50de54673::rapid_response_xblock"
+            "@2582bbb68672426297e525b49a383eb8::rapid_response_xblock"
         )
         self.scope_ids = make_scope_ids(self.runtime, self.aside_usage_key)
         self.aside_instance = RapidResponseAside(
@@ -67,3 +78,69 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         with patch.object(self.aside_instance, 'is_staff', return_value=is_staff):
             resp = self.aside_instance.toggle_block_open_status()
         assert resp.status_code == expected_status
+
+    @data(*[
+        [True, 200],
+        [False, 403]
+    ])
+    @unpack
+    def test_responses_staff_only(self, is_staff, expected_status):
+        """
+        Test that only staff users should access the API
+        """
+        with patch.object(self.aside_instance, 'is_staff', return_value=is_staff):
+            resp = self.aside_instance.responses()
+        assert resp.status_code == expected_status
+
+    @data(True, False)
+    def test_responses_open(self, is_open):
+        """
+        Test that the responses API shows whether the problem is open
+        """
+        RapidResponseBlockStatus.objects.create(
+            usage_key=self.aside_instance.wrapped_block_usage_key,
+            course_key=self.aside_instance.course_key,
+            open=is_open,
+        )
+
+        resp = self.aside_instance.responses()
+        assert resp.status_code == 200
+        assert resp.json['is_open'] == is_open
+
+    @pytest.mark.usefixtures("example_event")
+    def test_responses(self):
+        """
+        Test that the responses API will show recorded events during the open period
+        """
+        event = self.example_event
+        event_before = dict_with(event, {'test_data': 'before'})
+        event_during = dict_with(event, {'test_data': 'during'})
+        event_after = dict_with(event, {'test_data': 'after'})
+
+        problem_id = UsageKey.from_string(event['event']['problem_id'])
+        course_id = CourseLocator.from_string(event['context']['course_id'])
+
+        recorder = SubmissionRecorder()
+        recorder.send(event_before)
+        block_status = RapidResponseBlockStatus.objects.create(
+            usage_key=problem_id,
+            course_key=course_id,
+            open=True,
+        )
+        recorder.send(event_during)
+        block_status.open = False
+        block_status.save()
+        recorder.send(event_after)
+
+        assert RapidResponseSubmission.objects.count() == 1
+        submission = RapidResponseSubmission.objects.first()
+        assert submission.event['test_data'] == event_during['test_data']
+
+        resp = self.aside_instance.responses()
+        assert resp.status_code == 200
+        assert resp.json['is_open'] is False
+        assert resp.json['responses'] == [{
+            'id': submission.id,
+            'answer_id': submission.answer_id,
+            'answer_text': submission.answer_text,
+        }]

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -30,7 +30,7 @@ class TestEvents(RuntimeEnabledTestCase):
 
     def setUp(self):
         super(TestEvents, self).setUp()
-        self.scope_ids = make_scope_ids(self.runtime, self.course.id)
+        self.scope_ids = make_scope_ids(self.runtime, self.descriptor)
 
         # For the test_data course
         RapidResponseBlockStatus.objects.create(

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -34,7 +34,7 @@ class TestEvents(RuntimeEnabledTestCase):
         self.scope_ids = make_scope_ids(self.runtime, self.descriptor)
 
         # For the test_data course
-        RapidResponseBlockStatus.objects.create(
+        self.test_data_status = RapidResponseBlockStatus.objects.create(
             usage_key=UsageKey.from_string(
                 "i4x://SGAU/SGA101/problem/2582bbb68672426297e525b49a383eb8"
             ),
@@ -48,7 +48,7 @@ class TestEvents(RuntimeEnabledTestCase):
         usage_key = UsageKey.from_string(
             "block-v1:ReplaceStatic+ReplaceStatic+2018_T1+type@problem+block@2582bbb68672426297e525b49a383eb8"
         )
-        RapidResponseBlockStatus.objects.create(
+        self.example_status = RapidResponseBlockStatus.objects.create(
             usage_key=usage_key,
             course_key=usage_key.course_key,
             open=True,
@@ -240,23 +240,16 @@ class TestEvents(RuntimeEnabledTestCase):
         event_during = combine_dicts(event, {'test_data': 'during'})
         event_after = combine_dicts(event, {'test_data': 'after'})
 
-        problem_id = UsageKey.from_string(event['event']['problem_id'])
-        course_id = CourseLocator.from_string(event['context']['course_id'])
-
-        block_status = RapidResponseBlockStatus.objects.get(
-            usage_key=problem_id,
-            course_key=course_id,
-        )
-        block_status.open = False
-        block_status.save()
+        self.example_status.open = False
+        self.example_status.save()
 
         recorder = SubmissionRecorder()
         recorder.send(event_before)
-        block_status.open = True
-        block_status.save()
+        self.example_status.open = True
+        self.example_status.save()
         recorder.send(event_during)
-        block_status.open = False
-        block_status.save()
+        self.example_status.open = False
+        self.example_status.save()
         recorder.send(event_after)
 
         assert RapidResponseSubmission.objects.count() == 1

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,6 +1,4 @@
 """Just here to verify tests are running"""
-import json
-import os
 import mock
 import pytest
 
@@ -8,27 +6,20 @@ from ddt import data, ddt, unpack
 from django.http.request import HttpRequest
 
 from opaque_keys.edx.keys import UsageKey
+from opaque_keys.edx.locator import CourseLocator
 from courseware.module_render import load_single_xblock
 from xmodule.capa_module import CapaDescriptor
 from xmodule.modulestore.django import modulestore
 
 from rapid_response_xblock.logger import SubmissionRecorder
-from rapid_response_xblock.models import RapidResponseSubmission
+from rapid_response_xblock.models import (
+    RapidResponseBlockStatus,
+    RapidResponseSubmission,
+)
 from tests.utils import (
     RuntimeEnabledTestCase,
     make_scope_ids,
 )
-
-
-BASE_DIR = os.path.dirname(os.path.realpath(__file__))
-
-
-@pytest.fixture(scope="function")
-def example_event(request):
-    """An example real event captured previously"""
-    with open(os.path.join(BASE_DIR, "..", "test_data", "example_event.json")) as f:
-        request.cls.example_event = json.load(f)
-        yield
 
 
 # pylint: disable=no-member
@@ -39,7 +30,28 @@ class TestEvents(RuntimeEnabledTestCase):
 
     def setUp(self):
         super(TestEvents, self).setUp()
-        self.scope_ids = make_scope_ids(self.runtime, self.descriptor)
+        self.scope_ids = make_scope_ids(self.runtime, self.course.id)
+
+        # For the test_data course
+        RapidResponseBlockStatus.objects.create(
+            usage_key=UsageKey.from_string(
+                "i4x://SGAU/SGA101/problem/2582bbb68672426297e525b49a383eb8"
+            ),
+            course_key=CourseLocator.from_string(
+                'SGAU/SGA101/2017_SGA'
+            ),
+            open=True,
+        )
+
+        # For the block id in example_event.json
+        usage_key = UsageKey.from_string(
+            "block-v1:ReplaceStatic+ReplaceStatic+2018_T1+type@problem+block@2582bbb68672426297e525b49a383eb8"
+        )
+        RapidResponseBlockStatus.objects.create(
+            usage_key=usage_key,
+            course_key=usage_key.course_key,
+            open=True,
+        )
 
     def get_problem(self):
         """
@@ -59,9 +71,9 @@ class TestEvents(RuntimeEnabledTestCase):
         request.META['SERVER_PORT'] = 1234
         return load_single_xblock(
             request=request,
-            course_id=self.course_id.to_deprecated_string(),
+            course_id=unicode(self.course_id),
             user_id=self.instructor.id,
-            usage_key_string=problem.location.to_deprecated_string()
+            usage_key_string=unicode(problem.location)
         )
 
     def test_publish(self):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,6 +15,7 @@ from student.tests.factories import AdminFactory
 from xblock.fields import ScopeIds
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
+from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.modulestore.xml_importer import import_course_from_xml
 
 
@@ -65,6 +66,7 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
         self.track_function = make_track_function(HttpRequest())
         self.student_data = Mock()
         self.course = self.import_test_course()
+        self.descriptor = ItemFactory(category="pure", parent=self.course)
         self.course_id = self.course.id
         self.instructor = StaffFactory.create(course_key=self.course_id)
         self.runtime = self.make_runtime()
@@ -79,7 +81,7 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
         runtime, _ = get_module_system_for_user(
             user=self.instructor,
             student_data=self.student_data,
-            descriptor=self.course,
+            descriptor=self.descriptor,
             course_id=self.course.id,
             track_function=self.track_function,
             xqueue_callback_url_prefix=Mock(),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -25,7 +25,6 @@ def make_scope_ids(runtime, usage_key):
     """
     Make scope ids
 
-    from opaque_keys.edx.keys import UsageKey
     Args:
         runtime (xblock.runtime.Runtime): A runtime
         usage_key (opaque_keys.edx.keys.UsageKey): A usage key

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -40,7 +40,7 @@ def make_scope_ids(runtime, usage_key):
     )
 
 
-def dict_with(dictionary, extras):
+def combine_dicts(dictionary, extras):
     """
     Similar to {**dictionary, **extras} in Python 3
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -15,7 +15,6 @@ from student.tests.factories import AdminFactory
 from xblock.fields import ScopeIds
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
-from xmodule.modulestore.tests.factories import ItemFactory
 from xmodule.modulestore.xml_importer import import_course_from_xml
 
 
@@ -25,12 +24,36 @@ BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 def make_scope_ids(runtime, usage_key):
     """
     Make scope ids
+
+    from opaque_keys.edx.keys import UsageKey
+    Args:
+        runtime (xblock.runtime.Runtime): A runtime
+        usage_key (opaque_keys.edx.keys.UsageKey): A usage key
+
+    Returns:
+        xblock.fields.ScopeIds: A ScopeIds object for the block for usage_key
     """
     block_type = 'fake'
     def_id = runtime.id_generator.create_definition(block_type)
     return ScopeIds(
         'user', block_type, def_id, usage_key
     )
+
+
+def dict_with(dictionary, extras):
+    """
+    Similar to {**dictionary, **extras} in Python 3
+
+    Args:
+        dictionary (dict): A dictionary
+        extras (dict): Another dictionary
+
+    Returns:
+        dict: A new dictionary with both key and value pairs
+    """
+    ret = dict(dictionary)
+    ret.update(extras)
+    return ret
 
 
 class RuntimeEnabledTestCase(ModuleStoreTestCase):
@@ -43,7 +66,6 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
         self.track_function = make_track_function(HttpRequest())
         self.student_data = Mock()
         self.course = self.import_test_course()
-        self.descriptor = ItemFactory(category="pure", parent=self.course)
         self.course_id = self.course.id
         self.instructor = StaffFactory.create(course_key=self.course_id)
         self.runtime = self.make_runtime()
@@ -58,7 +80,7 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
         runtime, _ = get_module_system_for_user(
             user=self.instructor,
             student_data=self.student_data,
-            descriptor=self.descriptor,
+            descriptor=self.course,
             course_id=self.course.id,
             track_function=self.track_function,
             xqueue_callback_url_prefix=Mock(),


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #11 
Fixes #12 
Fixes #21 

#### What's this PR do?
Adds a REST API to view aggregate answer data

#### How should this be manually tested?
You should see an empty HTML table to start with. Click the open button and verify that there is a REST API being polled every 3 seconds in the network tab. Click the close button and verify that the polling stopped.

Open it again and submit an answer. Wait three seconds and you should see it appear in the HTML table. Change your answer and you should see the answer get updated in the table.

Refresh the page. Verify that the HTML table appears and there is polling done every three seconds in the network tab.

Click the close button and refresh the page again. You should see the HTML table with the answer you selected. Choose a different answer and refresh the page. You should see only the old answer in the HTML table.
