### PR TITLE
Run pylint and pep8 outside pytest

### DIFF
--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -40,14 +40,33 @@ pip install -r test_requirements.txt
 # output the packages which are installed for logging
 pip freeze
 
-# adjust test files for integration tests
-cp /edx/app/edxapp/edx-platform/setup.cfg .
-
-# Increase max line length
-sed -i 's/\[tool:pytest\]/\[tool:pytest\]\npep8maxlinelength = 119\n/' ./setup.cfg
-
 mkdir -p test_root  # for edx
 
-pytest rapid_response_xblock tests --cov . --pep8 --pylint
+set +e
+
+pytest tests --cov .
+PYTEST_SUCCESS=$?
+pep8 rapid_response_xblock tests
+PEP8_SUCCESS=$?
+(cd /edx/app/edxapp/edx-platform; pylint /rapid-response-xblock/rapid_response_xblock /rapid-response-xblock/tests)
+PYLINT_SUCCESS=$?
+
+if [[ $PYTEST_SUCCESS -ne 0 ]]
+then
+    echo "pytest exited with a non-zero status"
+    exit $PYTEST_SUCCESS
+fi
+if [[ $PEP8_SUCCESS -ne 0 ]]
+then
+    echo "pep8 exited with a non-zero status"
+    exit $PEP8_SUCCESS
+fi
+if [[ $PYLINT_SUCCESS -ne 0 ]]
+then
+    echo "pylint exited with a non-zero status"
+    exit $PYLINT_SUCCESS
+fi
+
+set -e
 coverage xml
 codecov

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -41,6 +41,9 @@ mkdir -p test_root  # for edx
 
 set +e
 
+# We're running pep8 directly here since pytest-pep8 hasn't been updated in a while and has a bug
+# linting this project's code. pylint is also run directly since it seems cleaner to run them both
+# separately than to run one as a plugin and one by itself.
 pytest tests --cov .
 PYTEST_SUCCESS=$?
 pep8 rapid_response_xblock tests

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -34,9 +34,6 @@ pip install -e .
 # Install codecov so we can upload code coverage results
 pip install codecov
 
-# linting stuff not included with edx
-pip install -r test_requirements.txt
-
 # output the packages which are installed for logging
 pip freeze
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,55 @@
+[nosetests]
+logging-clear-handlers=1
+with-ignore-docstrings=1
+exclude-dir=lms/envs
+            cms/envs
+
+# Without this flag, nose adds /lib directories to the path,
+# which shadows the xblock library (among other things)
+no-path-adjustment=1
+
+process-timeout=300
+
+# Uncomment the following lines to open pdb when a test fails
+#nocapture=1
+#pdb=1
+
+[tool:pytest]
+pep8maxlinelength = 119
+DJANGO_SETTINGS_MODULE = lms.envs.test
+addopts = --nomigrations --reuse-db --durations=20
+# Enable default handling for all warnings, including those that are ignored by default;
+# but hide rate-limit warnings (because we deliberately don't throttle test user logins)
+# and field_data deprecation warnings (because fixing them requires a major low-priority refactoring)
+filterwarnings =
+    default
+    ignore:No request passed to the backend, unable to rate-limit:UserWarning
+    ignore::xblock.exceptions.FieldDataDeprecationWarning
+norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/envs
+python_classes =
+python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py
+
+[pep8]
+# error codes: http://pep8.readthedocs.org/en/latest/intro.html#error-codes
+# E501: line too long
+# E265: block comment should start with ‘# ‘
+#   We have lots of comments that look like "##### HEADING #####" which violate
+#   this rule, because they don't have a space after the first #. However,
+#   they're still perfectly reasonable comments, so we disable this rule.
+# W602: deprecated form of raising exception
+#   We do this in a few places to modify the exception message while preserving
+#   the traceback. See this blog post for more info:
+#   http://nedbatchelder.com/blog/200711/rethrowing_exceptions_in_python.html
+#   It's a little unusual, but we have good reasons for doing so, so we disable
+#   this rule.
+ignore=E501,E265,W602
+exclude=migrations,.git,.pycharm_helpers,.tox,test_root/staticfiles,node_modules
+
+[isort]
+indent='    '
+line_length=120
+multi_line_output=3
+skip=
+    envs
+    migrations
+    common/lib/safe_lxml/safe_lxml/etree.py

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,5 @@
+# NOTE: this is copied from edx-platform, with a modification to extend the pep8maxlinelength to 119
+
 [nosetests]
 logging-clear-handlers=1
 with-ignore-docstrings=1

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -1,2 +1,0 @@
-pytest-pep8
-pytest-pylint

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -29,7 +29,7 @@ from rapid_response_xblock.models import RapidResponseSubmission
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-@pytest.fixture(scope="class")
+@pytest.fixture
 def example_event(request):
     """An example real event captured previously"""
     with open(os.path.join(BASE_DIR, "..", "test_data", "example_event.json")) as f:

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -37,6 +37,7 @@ def example_event(request):
         yield
 
 
+# pylint: disable=no-member
 @pytest.mark.usefixtures("example_event")
 @ddt
 class TestEvents(ModuleStoreTestCase):


### PR DESCRIPTION
#### What are the relevant tickets?
None

#### What's this PR do?
Replaces pytest-pep8 and pytest-pylint with direct calls of the commands themselves. pytest-pep8 is causing problems on #18 and it doesn't appear to have been worked on in a long time

#### How should this be manually tested?
Tests should pass
