### PR TITLE
Added studio view so instructors can enable/disable a problem for rapid response

### DIFF
--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -1,3 +1,11 @@
+.xblock-editor .rapid-response-block {
+    padding: 20px;
+}
+
+.xblock-editor .rapid-response-block label {
+    font-size: 14px;
+}
+
 button.problem-status-toggle:hover {
     background-color: #065683;
     background-image: none;

--- a/rapid_response_xblock/static/html/rapid_studio.html
+++ b/rapid_response_xblock/static/html/rapid_studio.html
@@ -1,0 +1,11 @@
+<div class="rapid-response-block" data-enabled="{{ is_enabled }}">
+  <div class="rapid-response-content">
+  </div>
+
+  <script type="text/template" id="rapid-response-toggle-tmpl">
+    <label>
+      <input type="checkbox" class="rapid-enabled-toggle" <% if (is_enabled) { %>checked<% } %>/>
+      Enable problem for rapid-response
+    </label>
+  </script>
+</div>

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -12,6 +12,7 @@
     var rapidTopLevelSel = '.rapid-response-block';
     var rapidBlockContentSel = '.rapid-response-content';
     var rapidBlockResultsSel = '.rapid-response-results';
+    var problemStatusBtnSel = '.problem-status-toggle';
     var toggleTemplate = _.template($(element).find("#rapid-response-toggle-tmpl").text());
 
     // default values
@@ -29,8 +30,8 @@
       $rapidBlockContent.html(toggleTemplate(state));
       renderD3(state);
 
-      $rapidBlockContent.find('.problem-status-toggle').click(function(e) {
-        $.get(toggleStatusUrl).then(
+      $rapidBlockContent.find(problemStatusBtnSel).click(function() {
+        $.post(toggleStatusUrl).then(
           function(newState) {
             state = Object.assign({}, state, newState);
             render();
@@ -38,10 +39,6 @@
             if (state.is_open) {
               pollForResponses();
             }
-          }
-        ).fail(
-          function () {
-            console.log("toggle data FAILED [" + toggleStatusUrl + "]");
           }
         );
       });

--- a/rapid_response_xblock/static/js/src/rapid_studio.js
+++ b/rapid_response_xblock/static/js/src/rapid_studio.js
@@ -1,0 +1,41 @@
+(function($, _) {
+  'use strict';
+
+  function RapidResponseAsideStudioView(runtime, element) {
+    var toggleEnabledUrl = runtime.handlerUrl(element, 'toggle_block_enabled');
+    var $element = $(element);
+
+    var rapidTopLevelSel = '.rapid-response-block';
+    var rapidBlockContentSel = '.rapid-response-content';
+    var enabledCheckboxSel = '.rapid-enabled-toggle';
+    var toggleTemplate = _.template($(element).find("#rapid-response-toggle-tmpl").text());
+
+    function render(state) {
+      // Render template
+      var $rapidBlockContent = $element.find(rapidBlockContentSel);
+      $rapidBlockContent.html(toggleTemplate(state));
+
+      $rapidBlockContent.find(enabledCheckboxSel).click(function() {
+        $.post(toggleEnabledUrl).then(
+          function(state) {
+            render(state);
+          }
+        );
+      });
+    }
+
+    $(function() { // onLoad
+      var block = $element.find(rapidTopLevelSel);
+      var isEnabled = block.attr('data-enabled') === 'True';
+      render({
+        is_enabled: isEnabled
+      });
+    });
+  }
+
+  function initializeRapidResponseAside(runtime, element) {
+    return new RapidResponseAsideStudioView(runtime, element);
+  }
+
+  window.RapidResponseAsideStudioInit = initializeRapidResponseAside;
+}($, _));


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #9 

#### What's this PR do?
In the description

#### How should this be manually tested?
⚠️ NOTE: The `edx-platform` PR that enables the studio view needs to be merged before this one: https://github.com/mitodl/edx-platform/pull/83 ⚠️ 

Use the `edx-platform` branch that fixes the aside studio view (linked above). Then, in studio, open a multiple choice problem for editing, click the "Plugins" tab, and check the checkbox for a problem. After publishing, check the problem as an instructor/staff in LMS. You should see the Open/Close button
