### PR TITLE
Pass histogram from the backend and order by answer order

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,11 @@ install:
   # Travis's version of docker-compose doesn't understand :cached, and it's not required anyway, so this removes it
   - (cd devstack; sed -i 's/:cached//g' ./docker-compose-host.yml)
   - (cd devstack; make dev.clone)
+  - (cd edx-platform;
+      git remote add mitodl https://github.com/mitodl/edx-platform.git;
+      git fetch mitodl;
+      git checkout mitodl/master
+    )
 script: >
   cd devstack;
   DEVSTACK_WORKSPACE=$PWD/.. docker-compose

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -1,17 +1,18 @@
 """Rapid-response functionality"""
-
 import logging
 from functools import wraps
 from collections import namedtuple
 import pkg_resources
+
 from django.db import transaction
+from django.db.models import Count
 from django.template import Context, Template
 from django.utils.translation import ugettext_lazy as _
 from web_fragments.fragment import Fragment
 from webob.response import Response
-
 from xblock.core import XBlock, XBlockAside
 from xblock.fields import Scope, Boolean
+from xmodule.modulestore.django import modulestore
 
 from rapid_response_xblock.models import (
     RapidResponseBlockStatus,
@@ -157,15 +158,26 @@ class RapidResponseAside(XBlockAside):
             course_key=self.course_key
         ).first()
         is_open = False if not status else status.open
-        responses = list(
-            RapidResponseSubmission.objects.filter(
-                problem_usage_key=self.wrapped_block_usage_key,
-                course_key=self.course_key,
-            ).values('id', 'answer_id', 'answer_text')
-        )
+        histogram = RapidResponseSubmission.objects.filter(
+            problem_usage_key=self.wrapped_block_usage_key,
+            course_key=self.course_key,
+        ).values('answer_id').annotate(count=Count('answer_id'))
+        histogram_counts = {item['answer_id']: item['count'] for item in histogram}
+
+        problem = modulestore().get_item(self.wrapped_block_usage_key)
+        tree = problem.lcp.tree
+        choice_elements = tree.xpath('//choicegroup/choice')
+        choices = [
+            {
+                'answer_id': choice.get("name"),
+                'answer_text': choice.text,
+                'count': histogram_counts.get(choice.get("name"), 0)
+            } for choice in choice_elements
+        ]
+
         return Response(json_body={
             'is_open': is_open,
-            'responses': responses,
+            'histogram': choices,
         })
 
     @property

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -158,11 +158,11 @@ class RapidResponseAside(XBlockAside):
             course_key=self.course_key
         ).first()
         is_open = False if not status else status.open
-        histogram = RapidResponseSubmission.objects.filter(
+        response_data = RapidResponseSubmission.objects.filter(
             problem_usage_key=self.wrapped_block_usage_key,
             course_key=self.course_key,
         ).values('answer_id').annotate(count=Count('answer_id'))
-        histogram_counts = {item['answer_id']: item['count'] for item in histogram}
+        response_counts = {item['answer_id']: item['count'] for item in response_data}
 
         problem = modulestore().get_item(self.wrapped_block_usage_key)
         tree = problem.lcp.tree
@@ -171,13 +171,13 @@ class RapidResponseAside(XBlockAside):
             {
                 'answer_id': choice.get("name"),
                 'answer_text': choice.text,
-                'count': histogram_counts.get(choice.get("name"), 0)
+                'count': response_counts.get(choice.get("name"), 0)
             } for choice in choice_elements
         ]
 
         return Response(json_body={
             'is_open': is_open,
-            'histogram': choices,
+            'response_data': choices,
         })
 
     @property

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -19,7 +19,7 @@
     var state = {
       is_open: false,
       is_staff: false,
-      histogram: []
+      response_data: []
     };
 
     /**
@@ -135,7 +135,7 @@
      * @param {Object} state The current rendering state
      */
     function renderD3(state) {
-      var histogram = state.histogram;
+      var histogram = state.response_data;
 
       // Compute responses into information suitable for a bar graph.
       var histogramAnswerIds = _.pluck(histogram, 'answer_id');

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -8,7 +8,6 @@ from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator
 from openedx.core.lib.xblock_utils import get_aside_from_xblock
 import pytest
-from xmodule.modulestore.django import modulestore
 
 from rapid_response_xblock.block import RapidResponseAside
 from rapid_response_xblock.models import (

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -147,7 +147,6 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         request.session = request.environ
         store = modulestore()
         problem = store.get_item(problem_id)
-        problem.runtime = self.runtime
         problem.xmodule_runtime = self.runtime
         aside_block = get_aside_from_xblock(problem, self.aside_usage_key.aside_type)
 

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -2,13 +2,11 @@
 from ddt import data, ddt, unpack
 from mock import Mock, patch
 
-from courseware.module_render import handle_xblock_callback
 from django.contrib.auth.models import User
-from django.http.request import HttpRequest
-from django.test.client import Client, RequestFactory
+from django.test.client import RequestFactory
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator
-from openedx.core.lib.xblock_utils import is_xblock_aside, get_aside_from_xblock
+from openedx.core.lib.xblock_utils import get_aside_from_xblock
 import pytest
 from xmodule.modulestore.django import modulestore
 
@@ -165,9 +163,9 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         }
 
         for item in answer_data:
-            for n in range(counts[item['answer_id']]):
-                username = 'user_{}_{}'.format(n, item['answer_id'])
-                email = 'user{}{}@email.com'.format(n, item['answer_id'])
+            for number in range(counts[item['answer_id']]):
+                username = 'user_{}_{}'.format(number, item['answer_id'])
+                email = 'user{}{}@email.com'.format(number, item['answer_id'])
                 user = User.objects.create(
                     username=username,
                     email=email,

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -142,6 +142,15 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         # replace(deprecated=True) doesn't work for BlockUsageLocator
         problem_id = BlockUsageLocator(course_id, problem_id.block_type, problem_id.block_id, deprecated=True)
 
+        request = RequestFactory().request()
+        request.user = self.instructor
+        request.session = request.environ
+        store = modulestore()
+        problem = store.get_item(problem_id)
+        problem.runtime = self.runtime
+        problem.xmodule_runtime = self.runtime
+        aside_block = get_aside_from_xblock(problem, self.aside_usage_key.aside_type)
+
         answer_data = [
             {
                 'answer_id': 'choice_0',
@@ -194,15 +203,6 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             answer_text=answer_data[0]['answer_text'],
             event={}
         )
-
-        request = RequestFactory().request()
-        request.user = self.instructor
-        request.session = request.environ
-        store = modulestore()
-        problem = store.get_item(problem_id)
-        problem.runtime = self.runtime
-        problem.xmodule_runtime = self.runtime
-        aside_block = get_aside_from_xblock(problem, self.aside_usage_key.aside_type)
 
         with self.patch_modulestore():
             resp = aside_block.responses()

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -210,7 +210,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         assert resp.status_code == 200
         assert resp.json['is_open'] is False
 
-        assert resp.json['histogram'] == [{
+        assert resp.json['response_data'] == [{
             'count': counts[item['answer_id']],
             'answer_id': item['answer_id'],
             'answer_text': item['answer_text'],

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -149,20 +149,23 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         problem = self.get_problem_by_id(problem_id)
         aside_block = get_aside_from_xblock(problem, self.aside_usage_key.aside_type)
 
-        answer_id_counts = zip(range(3), range(2, 5))
-        answer_texts = [
-            'an incorrect answer',
-            'the correct answer',
-            'a different incorrect answer',
-        ]
+        answer_id_text_counts = zip(
+            range(3),
+            [
+                'an incorrect answer',
+                'the correct answer',
+                'a different incorrect answer',
+            ],
+            range(2, 5),
+        )
         answer_data = [
             {
                 'answer_id': 'choice_{}'.format(i),
-                'answer_text': answer_texts[i],
+                'answer_text': text,
             }
-            for i, _ in answer_id_counts
+            for i, text, _ in answer_id_text_counts
         ]
-        counts = {'choice_{}'.format(ans_id): ans_count for ans_id, ans_count in answer_id_counts}
+        counts = {'choice_{}'.format(ans_id): ans_count for ans_id, _, ans_count in answer_id_text_counts}
 
         for item in answer_data:
             for number in range(counts[item['answer_id']]):

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -142,12 +142,12 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         # replace(deprecated=True) doesn't work for BlockUsageLocator
         problem_id = BlockUsageLocator(course_id, problem_id.block_type, problem_id.block_id, deprecated=True)
 
+        # This problem is imported into the modulestore in the setup method.
+        # It needs to be present there to allow the view function to look up problem data.
         request = RequestFactory().request()
         request.user = self.instructor
         request.session = request.environ
-        store = modulestore()
-        problem = store.get_item(problem_id)
-        problem.xmodule_runtime = self.runtime
+        problem = self.get_problem_by_id(problem_id)
         aside_block = get_aside_from_xblock(problem, self.aside_usage_key.aside_type)
 
         answer_data = [

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -150,25 +150,20 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         problem = self.get_problem_by_id(problem_id)
         aside_block = get_aside_from_xblock(problem, self.aside_usage_key.aside_type)
 
+        answer_id_counts = zip(range(3), range(2, 5))
+        answer_texts = [
+            'an incorrect answer',
+            'the correct answer',
+            'a different incorrect answer',
+        ]
         answer_data = [
             {
-                'answer_id': 'choice_0',
-                'answer_text': 'an incorrect answer',
-            },
-            {
-                'answer_id': 'choice_1',
-                'answer_text': 'the correct answer',
-            },
-            {
-                'answer_id': 'choice_2',
-                'answer_text': 'a different incorrect answer',
-            },
+                'answer_id': 'choice_{}'.format(i),
+                'answer_text': answer_texts[i],
+            }
+            for i, _ in answer_id_counts
         ]
-        counts = {
-            'choice_0': 5,
-            'choice_1': 4,
-            'choice_2': 3,
-        }
+        counts = {'choice_{}'.format(ans_id): ans_count for ans_id, ans_count in answer_id_counts}
 
         for item in answer_data:
             for number in range(counts[item['answer_id']]):

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -119,6 +119,11 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
 
     @contextmanager
     def patch_modulestore(self):
+        """
+        Set xmodule_runtime and xmodule_runtime.xmodule_instance on blocks retrieved from the modulestore.
+
+        Only applies if get_item is used.
+        """
         store = modulestore()
 
         def wrap_runtime(*args, **kwargs):
@@ -132,7 +137,7 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
                 block.module_class,
                 descriptor=block,
                 scope_ids=block.scope_ids,
-                field_data=block._field_data,
+                field_data=block._field_data,  # pylint: disable=protected-access
                 for_parent=block.get_parent()
             )
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -146,3 +146,18 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
         with patch('rapid_response_xblock.block.modulestore', autospec=True) as modulestore_mock:
             modulestore_mock.return_value.get_item.side_effect = wrap_runtime
             yield modulestore_mock
+
+    def get_problem_by_id(self, problem_id):
+        """
+        Get a problem from the modulestore and assign the runtime
+
+        Args:
+            problem_id (UsageKey): A usage key for a problem
+
+        Returns:
+            CapaDescriptor: A problem
+        """
+        store = modulestore()
+        problem = store.get_item(problem_id)
+        problem.xmodule_runtime = self.runtime
+        return problem


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #26 

#### What's this PR do?
Refactors the responses API to calculate the histogram in the database, and orders the answers by the problem OLX choices.

#### How should this be manually tested?
You should see all answers in the x ticks even if there are no submissions. Submit an answer then verify that the bar shows up in the right place.

Also note that if you edit `choicegroup` to add the attribute `shuffle="true"` the choices will appear in a random order, but the bars will also follow that same order.
