### PR TITLE
Add database models to store runs

### DIFF
--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -158,7 +158,7 @@ class RapidResponseAside(XBlockAside):
         runs = RapidResponseRun.objects.filter(
             problem_usage_key=self.wrapped_block_usage_key,
             course_key=self.course_key,
-        ).order_by('created')
+        ).order_by('-created')
         is_open = runs.filter(open=True).exists()
         response_data = RapidResponseSubmission.objects.filter(
             run__problem_usage_key=self.wrapped_block_usage_key,

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -92,7 +92,7 @@ def get_choices_from_problem(problem_key):
     ]
 
 
-def get_serialized_runs(course_key, problem_usage_key):
+def get_runs(course_key, problem_usage_key):
     """
     Look up rapid response runs for a problem and return a serialized representation
 
@@ -233,7 +233,7 @@ class RapidResponseAside(XBlockAside):
         """
         Returns student responses for rapid-response-enabled block
         """
-        runs = get_serialized_runs(self.course_key, self.wrapped_block_usage_key)
+        runs = get_runs(self.course_key, self.wrapped_block_usage_key)
         # Only the most recent run should possibly be open
         is_open = runs[0]['open'] if runs else False
         choices = get_choices_from_problem(self.wrapped_block_usage_key)

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -155,11 +155,12 @@ class RapidResponseAside(XBlockAside):
         """
         Returns student responses for rapid-response-enabled block
         """
-        runs = RapidResponseRun.objects.filter(
+        runs = list(RapidResponseRun.objects.filter(
             problem_usage_key=self.wrapped_block_usage_key,
             course_key=self.course_key,
-        ).order_by('-created')
-        is_open = runs.filter(open=True).exists()
+        ).order_by('-created'))
+        # Only the most recent run should possibly be open
+        is_open = runs[0].open if runs else False
         response_data = RapidResponseSubmission.objects.filter(
             run__problem_usage_key=self.wrapped_block_usage_key,
             run__course_key=self.course_key,

--- a/rapid_response_xblock/migrations/0004_run.py
+++ b/rapid_response_xblock/migrations/0004_run.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+from __future__ import unicode_literals
+
+from django.db import migrations, models
+import django.db.models.deletion
+import django.utils.timezone
+import model_utils.fields
+import opaque_keys.edx.django.models
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ('rapid_response_xblock', '0003_rename_fields'),
+    ]
+
+    operations = [
+        migrations.CreateModel(
+            name='RapidResponseRun',
+            fields=[
+                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
+                ('created', model_utils.fields.AutoCreatedField(default=django.utils.timezone.now, verbose_name='created', editable=False)),
+                ('modified', model_utils.fields.AutoLastModifiedField(default=django.utils.timezone.now, verbose_name='modified', editable=False)),
+                ('name', models.TextField()),
+                ('problem_usage_key', opaque_keys.edx.django.models.UsageKeyField(max_length=255, db_index=True)),
+                ('course_key', opaque_keys.edx.django.models.CourseKeyField(max_length=255, db_index=True)),
+                ('open', models.BooleanField(default=False)),
+            ],
+            options={
+                'abstract': False,
+            },
+        ),
+        migrations.DeleteModel(
+            name='RapidResponseBlockStatus',
+        ),
+        migrations.RemoveField(
+            model_name='rapidresponsesubmission',
+            name='course_key',
+        ),
+        migrations.RemoveField(
+            model_name='rapidresponsesubmission',
+            name='problem_usage_key',
+        ),
+        migrations.AddField(
+            model_name='rapidresponsesubmission',
+            name='run',
+            field=models.ForeignKey(on_delete=django.db.models.deletion.SET_NULL, to='rapid_response_xblock.RapidResponseRun', null=True),
+        ),
+    ]

--- a/rapid_response_xblock/models.py
+++ b/rapid_response_xblock/models.py
@@ -15,6 +15,31 @@ from opaque_keys.edx.django.models import (
 
 
 @python_2_unicode_compatible
+class RapidResponseRun(models.Model):
+    """
+    Stores information for a group of RapidResponseSubmission objects
+    """
+    problem_usage_key = UsageKeyField(db_index=True, max_length=255)
+    course_key = CourseKeyField(db_index=True, max_length=255)
+    open = models.BooleanField(default=False, null=False)
+
+    created = models.DateTimeField(auto_now_add=True, db_index=True)
+    modified = models.DateTimeField(auto_now=True)
+
+    def __str__(self):
+        return (
+            "id={id} created={created} problem_usage_key={problem_usage_key} "
+            "course_key={course_key} open={open}".format(
+                id=self.id,
+                created=self.created.isoformat(),
+                problem_usage_key=self.problem_usage_key,
+                course_key=self.course_key,
+                open=self.open,
+            )
+        )
+
+
+@python_2_unicode_compatible
 class RapidResponseSubmission(TimeStampedModel):
     """
     Stores the student submissions for a problem that is
@@ -26,39 +51,21 @@ class RapidResponseSubmission(TimeStampedModel):
         null=True,
         db_index=True,
     )
-    problem_usage_key = UsageKeyField(db_index=True, max_length=255)
-    course_key = CourseKeyField(db_index=True, max_length=255)
+    run = models.ForeignKey(
+        RapidResponseRun,
+        on_delete=models.SET_NULL,
+        null=True,
+        db_index=True
+    )
     answer_id = models.CharField(null=True, max_length=255)
     answer_text = models.CharField(null=True, max_length=4096)
     event = JSONField()
 
     def __str__(self):
         return (
-            "user={user} problem_usage_key={problem_usage_key} course_key={course_key} "
-            "answer_id={answer_id}".format(
+            "user={user} run={run} answer_id={answer_id}".format(
                 user=self.user,
-                problem_usage_key=self.problem_usage_key,
-                course_key=self.course_key,
+                run=self.run,
                 answer_id=self.answer_id,
-            )
-        )
-
-
-@python_2_unicode_compatible
-class RapidResponseBlockStatus(models.Model):
-    """
-    Indicates whether a rapid-response-enabled XBlock for a given course is "open" or not
-    ("open" = set to collect student responses for the block in real time)
-    """
-    problem_usage_key = UsageKeyField(max_length=255, db_index=True)
-    course_key = CourseKeyField(max_length=255, db_index=True)
-    open = models.BooleanField(default=False, null=False)
-
-    def __str__(self):
-        return (
-            "open={open} problem_usage_key={problem_usage_key} course_key={course_key}".format(
-                open=self.open,
-                problem_usage_key=self.problem_usage_key,
-                course_key=self.course_key
             )
         )

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -144,7 +144,7 @@
       // HACK: only show the latest run for now
       var mostRecentRun = null;
       if (runs.length > 0) {
-        mostRecentRun = runs[runs.length - 1].id;
+        mostRecentRun = runs[0].id;
       }
 
       var histogram = choices.map(function (item) {

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -19,7 +19,9 @@
     var state = {
       is_open: false,
       is_staff: false,
-      response_data: []
+      runs: [],
+      choices: [],
+      counts: {}
     };
 
     /**
@@ -135,7 +137,23 @@
      * @param {Object} state The current rendering state
      */
     function renderD3(state) {
-      var histogram = state.response_data;
+      var runs = state.runs;
+      var counts = state.counts;
+      var choices = state.choices;
+
+      // HACK: only show the latest run for now
+      var mostRecentRun = null;
+      if (runs.length > 0) {
+        mostRecentRun = runs[runs.length - 1].id;
+      }
+
+      var histogram = choices.map(function (item) {
+        return {
+          answer_id: item.answer_id,
+          answer_text: item.answer_text,
+          count: counts[item.answer_id][mostRecentRun] || 0
+        }
+      });
 
       // Compute responses into information suitable for a bar graph.
       var histogramAnswerIds = _.pluck(histogram, 'answer_id');

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -6,8 +6,6 @@ from mock import Mock, patch
 from django.contrib.auth.models import User
 from opaque_keys.edx.keys import UsageKey
 from opaque_keys.edx.locator import BlockUsageLocator
-from openedx.core.lib.xblock_utils import get_aside_from_xblock
-import pytest
 
 from rapid_response_xblock.block import (
     get_choices_from_problem,

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -239,7 +239,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             counts_dict[answer_id][run_id] = num_submissions
 
             answer_text = choices_lookup[answer_id]
-            for number in range(num_submissions):
+            for _ in range(num_submissions):
                 user = UserFactory.create()
 
                 RapidResponseSubmission.objects.create(

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -191,37 +191,6 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         get_choices_mock.assert_called_once_with(problem_id)
         get_counts_mock.assert_called_once_with(course_id, problem_id, runs, choices)
 
-    def test_zero_runs(self):
-        """
-        If there are no runs there should still be valid answers
-        """
-        problem_id = self.aside_instance.wrapped_block_usage_key
-        problem = self.get_problem_by_id(problem_id)
-        aside_block = get_aside_from_xblock(problem, self.aside_usage_key.aside_type)
-
-        with self.patch_modulestore():
-            resp = aside_block.responses()
-
-        assert resp.status_code == 200
-        assert resp.json['is_open'] is False
-
-        answers = [
-            ('choice_0', 'an incorrect answer'),
-            ('choice_1', 'the correct answer'),
-            ('choice_2', 'a different incorrect answer'),
-        ]
-
-        assert resp.json['choices'] == [
-            {
-                'answer_id': answer_id,
-                'answer_text': answer_text,
-            } for answer_id, answer_text in answers
-        ]
-        assert resp.json['runs'] == []
-        assert resp.json['counts'] == {
-            answer_id: {} for answer_id, _ in answers
-        }
-
     def test_get_choices_from_problem(self):
         """
         get_choices_from_problem should return a serialized representation of choices from a problem OLX

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -236,10 +236,9 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         ))
 
         counts_dict = defaultdict(dict)
-        for answer_id, count, run_id in counts:
-            counts_dict[answer_id][run_id] = count
-
         for answer_id, num_submissions, run_id in counts:
+            counts_dict[answer_id][run_id] = num_submissions
+
             answer_text = choices_lookup[answer_id]
             for number in range(num_submissions):
                 username = 'user_{}_{}'.format(number, answer_id)

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -225,15 +225,15 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             {'answer_id': 'choice_2', 'answer_text': 'a different incorrect answer'},
         ]
         choices_lookup = {choice['answer_id']: choice['answer_text'] for choice in choices}
-        counts = list(zip(
+        counts = zip(
             [choices[i]['answer_id'] for i in range(3)],
             range(2, 5),
             [run1.id for _ in range(3)],
-        )) + list(zip(
+        ) + zip(
             [choices[i]['answer_id'] for i in range(3)],
             [3, 0, 7],
             [run2.id for _ in range(3)],
-        ))
+        )
 
         counts_dict = defaultdict(dict)
         for answer_id, num_submissions, run_id in counts:

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -148,7 +148,6 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         assert resp.status_code == 200
         assert resp.json['is_open'] == is_open
 
-    @pytest.mark.usefixtures("example_event")
     def test_responses(self):
         """
         Test that the responses API will show recorded events during the open period
@@ -245,6 +244,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         assert resp.json['runs'] == [{
             'id': run.id,
             'created': run.created.isoformat(),
+            'open': run.open,
         } for run in [run2, run1]]
         assert resp.json['counts'] == counts_dict
 

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -5,6 +5,7 @@ from mock import Mock, patch, PropertyMock
 
 from django.contrib.auth.models import User
 from opaque_keys.edx.keys import UsageKey
+from student.tests.factories import UserFactory
 
 from rapid_response_xblock.block import (
     RapidResponseAside,
@@ -240,12 +241,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
 
             answer_text = choices_lookup[answer_id]
             for number in range(num_submissions):
-                username = 'user_{}_{}'.format(number, answer_id)
-                email = 'user{}{}@email.com'.format(number, answer_id)
-                user, _ = User.objects.get_or_create(
-                    username=username,
-                    email=email,
-                )
+                user = UserFactory.create()
 
                 RapidResponseSubmission.objects.create(
                     # For some reason the modulestore looks for a deprecated course key

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -5,7 +5,6 @@ from mock import Mock, patch, PropertyMock
 
 from django.contrib.auth.models import User
 from opaque_keys.edx.keys import UsageKey
-from opaque_keys.edx.locator import BlockUsageLocator
 
 from rapid_response_xblock.block import (
     RapidResponseAside,

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -3,7 +3,6 @@ from collections import defaultdict
 from ddt import data, ddt, unpack
 from mock import Mock, patch, PropertyMock
 
-from django.contrib.auth.models import User
 from opaque_keys.edx.keys import UsageKey
 from student.tests.factories import UserFactory
 

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -245,7 +245,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         assert resp.json['runs'] == [{
             'id': run.id,
             'created': run.created.isoformat(),
-        } for run in [run1, run2]]
+        } for run in [run2, run1]]
         assert resp.json['counts'] == counts_dict
 
     def test_zero_responses(self):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -13,7 +13,7 @@ from xmodule.modulestore.django import modulestore
 
 from rapid_response_xblock.logger import SubmissionRecorder
 from rapid_response_xblock.models import (
-    RapidResponseBlockStatus,
+    RapidResponseRun,
     RapidResponseSubmission,
 )
 from tests.utils import (
@@ -34,7 +34,7 @@ class TestEvents(RuntimeEnabledTestCase):
         self.scope_ids = make_scope_ids(self.runtime, self.descriptor)
 
         # For the test_data course
-        self.test_data_status = RapidResponseBlockStatus.objects.create(
+        self.test_data_status = RapidResponseRun.objects.create(
             problem_usage_key=UsageKey.from_string(
                 "i4x://SGAU/SGA101/problem/2582bbb68672426297e525b49a383eb8"
             ),
@@ -48,7 +48,7 @@ class TestEvents(RuntimeEnabledTestCase):
         usage_key = UsageKey.from_string(
             "block-v1:ReplaceStatic+ReplaceStatic+2018_T1+type@problem+block@2582bbb68672426297e525b49a383eb8"
         )
-        self.example_status = RapidResponseBlockStatus.objects.create(
+        self.example_status = RapidResponseRun.objects.create(
             problem_usage_key=usage_key,
             course_key=usage_key.course_key,
             open=True,
@@ -126,8 +126,8 @@ class TestEvents(RuntimeEnabledTestCase):
         assert RapidResponseSubmission.objects.count() == 1
         obj = RapidResponseSubmission.objects.first()
         assert obj.user_id == self.instructor.id
-        assert obj.course_key == self.course.course_id
-        assert obj.problem_usage_key.map_into_course(
+        assert obj.run.course_key == self.course.course_id
+        assert obj.run.problem_usage_key.map_into_course(
             self.course.course_id
         ) == problem.location
         assert obj.answer_text == expected_answer_text
@@ -148,8 +148,8 @@ class TestEvents(RuntimeEnabledTestCase):
         assert RapidResponseSubmission.objects.count() == 1
         obj = RapidResponseSubmission.objects.first()
         assert obj.user_id == self.instructor.id
-        assert obj.course_key == self.course.course_id
-        assert obj.problem_usage_key.map_into_course(
+        assert obj.run.course_key == self.course.course_id
+        assert obj.run.problem_usage_key.map_into_course(
             self.course.course_id
         ) == problem.location
         # Answer is the first one clicked
@@ -163,10 +163,10 @@ class TestEvents(RuntimeEnabledTestCase):
         assert RapidResponseSubmission.objects.count() == 1
         obj = RapidResponseSubmission.objects.first()
         assert obj.user_id == example_event_data['context']['user_id']
-        assert obj.problem_usage_key == UsageKey.from_string(
+        assert obj.run.problem_usage_key == UsageKey.from_string(
             example_event_data['event']['problem_id']
         )
-        assert obj.course_key == CourseLocator.from_string(
+        assert obj.run.course_key == CourseLocator.from_string(
             example_event_data['context']['course_id']
         )
         # Answer is the first one clicked


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #29 

#### What's this PR do?
Creates a `RapidResponseRun` to store information about multiple rounds of submissions. This replaces `RapidResponseBlockStatus` since this information is already in `RapidResponseRun`. 

#### How should this be manually tested?
The only user facing thing you should notice is that when you close and open a problem, the old results should go away. They will still come through the API and be present in the database but they are filtered out in the front end (for now).

#### Any background context you want to provide?
You should probably get rid of all `RapidResponseSubmission` to avoid stale data. There is no data migration from the old format into the new one
