### PR TITLE
Add graph switcher

### DIFF
--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -1,6 +1,8 @@
 <div class="rapid-response-block" data-staff="{{ is_staff }}" data-open="{{ is_open }}">
   <div class="rapid-response-content">
   </div>
+  <div class="rapid-response-run-selection">
+  </div>
   <div class="rapid-response-results">
   </div>
 


### PR DESCRIPTION
#### What are the relevant tickets?
Part of #29 

#### What's this PR do?
Add logic and select item to switch runs

#### How should this be manually tested?
 - Load page. You should see most recent graph
 - Open the problem. The graph should clear and the select should change to a new item for the current time.
 - Submit a response. It should appear in the graph soon after.
 - Switch responses. You should see the graph update.
 - Switch to 'None'. The graph should disappear. Switch to another response and the graph should show up again.