### PR TITLE
Limited rapid response block to multiple choice problems

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -41,5 +41,8 @@ setup(
         'lms.djangoapp': [
             'rapid_response_xblock = rapid_response_xblock.apps:RapidResponseAppConfig'
         ],
+        'cms.djangoapp': [
+            'rapid_response_xblock = rapid_response_xblock.apps:RapidResponseAppConfig'
+        ],
     }
 )

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -209,19 +209,19 @@ class TestEvents(RuntimeEnabledTestCase):
         If there is more than one submission in the event,
         no event should be recorded
         """
-        key = '2582bbb68672426297e525b49a383eb8_2_1'
-        submission = self.example_event['event']['submission'][key]
-        self.example_event['event']['submission']['second'] = submission
+        submission = self.example_event['event']['submission'].values()[0]
+        self.example_event['event']['submission']['new_key'] = submission
         SubmissionRecorder().send(self.example_event)
         self.assert_unsuccessful_event_parsing()
 
-    def test_no_submission(self):
+    @data(None, {})
+    def test_no_submission(self, submission_value):
         """
-        If there is more than one submission in the event,
+        If there is no submission or an empty submission in the event,
         no event should be recorded
         """
-        key = '2582bbb68672426297e525b49a383eb8_2_1'
-        self.example_event['event']['submission'][key] = None
+        key = self.example_event['event']['submission'].keys()[0]
+        self.example_event['event']['submission'][key] = submission_value
         SubmissionRecorder().send(self.example_event)
         self.assert_unsuccessful_event_parsing()
 


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #32 

#### What's this PR do?
Limits the rapid response block to multiple choice problems

#### How should this be manually tested?
Your devstack instance needs to have `XBlock==1.2.0` installed for this to work (PR for that change in `edx-platform`: https://github.com/mitodl/edx-platform/pull/85)

The only user-noticeable change is in Studio. When you click the Edit button for a non-multiple-choice problem, you should not see the "Plugins" tab.

You can also test LMS to make sure that (a) multiple choice submissions are still captured for open problems, and (b) non-multiple-choice problems are not captured

#### Where should the reviewer start?
`rapid_response_xblock/block.py` and `rapid_response_xblock/logger.py`

#### Any background context you want to provide?
It made sense to refactor the capturing of the problem submissions as part of this. The parsing & rapid response-related logic is now separate. I also limited the behavior that we consider exceptional in the parsing logic.
