### PR TITLE
Add comparison view for graphs

### DIFF
--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -52,7 +52,7 @@ text.message {
     display: flex;
 }
 
-.selection-row a {
+.selection-container a {
     padding: 0 10px;
     cursor: pointer;
 }
@@ -61,7 +61,7 @@ text.message {
     color: black;
 }
 
-.selection-row {
+.selection-container {
     font-size: 16pt;
 }
 

--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -64,3 +64,7 @@ text.message {
 .selection-row {
     font-size: 16pt;
 }
+
+.wrap-instructor-info {
+    visibility: hidden;
+}

--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -1,3 +1,8 @@
+.rapid-response-block {
+    background-color: #f7f7f7;
+    padding: 25px;
+}
+
 .xblock-editor .rapid-response-block {
     padding: 20px;
 }
@@ -6,9 +11,16 @@
     font-size: 14px;
 }
 
+button.problem-status-toggle {
+    border-radius: 5px;
+    border: 2px solid #1176b2;
+    color: #1176b2;
+    background: transparent;
+    font-weight: 700;
+}
+
 button.problem-status-toggle:hover {
-    background-color: #065683;
-    background-image: none;
+    background: #065683 none;
     box-shadow: none;
 }
 
@@ -16,8 +28,16 @@ button.problem-status-toggle:hover {
     border: 1px solid black;
 }
 
-.tick text {
+.single-chart .tick text {
     font-size: 30pt;
+}
+
+.two-charts .tick text {
+    font-size: 20pt;
+}
+
+.two-charts svg {
+    background-color: #ebebeb;
 }
 
 text.message {
@@ -26,4 +46,21 @@ text.message {
 
 .hidden {
     display: none;
+}
+
+.rapid-response-results {
+    display: flex;
+}
+
+.selection-row a {
+    padding: 0 10px;
+    cursor: pointer;
+}
+
+.chart-title {
+    color: black;
+}
+
+.selection-row {
+    font-size: 16pt;
 }

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -1,14 +1,15 @@
 <div class="rapid-response-block" data-staff="{{ is_staff }}" data-open="{{ is_open }}">
+  <h3 class="chart-title">Live Response</h3>
   <div class="rapid-response-content">
   </div>
   <div class="rapid-response-results">
   </div>
 
   <script type="text/template" id="rapid-response-toggle-tmpl">
-    <% if (is_staff) { %>
+    <% if (is_staff && selectedRuns.length === 1) { %>
       <p>
         <button class="btn btn-brand problem-status-toggle">
-          <%= is_open ? "Close" : "Open" %> Problem For Live Responses
+          <%= is_open ? "Close" : "Open" %> Problem Now
         </button>
       </p>
     <% } %>

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -47,7 +47,7 @@
     function render() {
       var $rapidBlockContent = $element.find(rapidBlockContentSel);
       $rapidBlockContent.html(toggleTemplate(state));
-      renderD3();
+      renderChartContainer();
 
       $rapidBlockContent.find(problemStatusBtnSel).click(function() {
         $.post(toggleStatusUrl).then(
@@ -162,9 +162,9 @@
     }
 
     /**
-     * Renders the graph and adjusts axes based on responses to the given problem.
+     * Renders the container elements for the charts using D3
      */
-    function renderD3() {
+    function renderChartContainer() {
       // Get the indexes for selected runs. This should either be [0] or [0, 1].
       var chartKeys = _.keys(state.selectedRuns);
 

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -176,7 +176,7 @@
 
       var selectionRowsMerged = selectionRowsEnter.merge(selectionRows);
       selectionRowsMerged.selectAll(".compare-responses").classed("hidden", function() {
-        return chartKeys.length !== 1 || state.is_open;
+        return chartKeys.length !== 1 || state.is_open || state.runs.length < 2;
       });
       selectionRowsMerged.selectAll(".close").classed("hidden", function() {
         return chartKeys.length === 1;
@@ -220,7 +220,8 @@
       var selectedRun = state.selectedRuns[chartIndex];
 
       // select the proper option and use it to filter the runs
-      var select = container.select(".selection-row").select("select");
+      var select = container.select(".selection-row").select("select")
+        .classed("hidden", state.runs.length === 0);
       if (selectedRun === null && runs.length > 0) {
         // The newest run should be the most recent one according to the info received from the server.
         selectedRun = runs[0].id;

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -174,31 +174,31 @@
         .select(rapidBlockResultsSel)
         .selectAll(".chart-container")
         .data(chartKeys);
-      var containersEnter = containers.enter()
+      var newContainers = containers.enter()
         .append("div");
 
       // chart selection, close and compare buttons
       var selectionContainers = containers.selectAll(".selection-container");
-      var selectionContainersEnter = containersEnter
+      var newSelectionContainers = newContainers
         .append("div")
         .classed("selection-container", true);
 
-      selectionContainersEnter.append("select")
+      newSelectionContainers.append("select")
         .on('change', changeSelectedChart);
 
-      selectionContainersEnter.append("a")
+      newSelectionContainers.append("a")
         .classed("compare-responses", true)
         .text("Compare responses")
         .on("click", openNewChart);
 
-      selectionContainersEnter.append("a")
+      newSelectionContainers.append("a")
         .classed("close", true)
         .text("Close ")  // trailing space is intentional, CSS will add a 'X' right after
         .on('click', closeChart)
         .append("span")
         .attr("class", "fa fa-close");
 
-      var selectionRowsMerged = selectionContainersEnter.merge(selectionContainers);
+      var selectionRowsMerged = newSelectionContainers.merge(selectionContainers);
       selectionRowsMerged.selectAll(".compare-responses").classed("hidden", function() {
         return chartKeys.length !== 1 || state.is_open || state.runs.length < 2;
       });
@@ -207,15 +207,15 @@
       });
 
       // create the chart svg container
-      var chartsEnter = containersEnter
+      var newCharts = newContainers
         .append("svg")
         // The g element has a little bit of padding so the x and y axes can surround it
         .append("g").attr("class", "chart");
       // create x and y axes
-      chartsEnter.append("g").attr("class", "xaxis").attr("transform", "translate(0," + ChartSettings.height + ")");
-      chartsEnter.append("g").attr("class", "yaxis");
+      newCharts.append("g").attr("class", "xaxis").attr("transform", "translate(0," + ChartSettings.height + ")");
+      newCharts.append("g").attr("class", "yaxis");
 
-      containersEnter.merge(containers)
+      newContainers.merge(containers)
         .attr("class", "chart-container " + (chartKeys.length === 1 ? 'single-chart' : 'two-charts'))
         .each(function (index, __, charts) {
           renderChart(d3.select(charts[index]), index);

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -133,6 +133,36 @@
     }
 
     /**
+     * Click handler to close this chart
+     * @param {number} chartIndex The index of the chart
+     */
+    function closeChart(chartIndex) {
+      state.selectedRuns.splice(chartIndex, 1);
+      render();
+    }
+
+    /**
+     * Select handler to choose a different run for the chart
+     * @param {number} chartIndex The index of the chart
+     */
+    function changeSelectedChart(chartIndex) {
+      var selectedRun = this.value;
+      if (selectedRun !== NONE_SELECTION) {
+        selectedRun = parseInt(selectedRun);
+      }
+      state.selectedRuns[chartIndex] = selectedRun;
+      render();
+    }
+
+    /**
+     * Click handler to open a new chart for comparison
+     */
+    function openNewChart() {
+      state.selectedRuns = [state.selectedRuns[0], NONE_SELECTION];
+      render();
+    }
+
+    /**
      * Renders the graph and adjusts axes based on responses to the given problem.
      */
     function renderD3() {
@@ -153,27 +183,20 @@
         .append("div")
         .classed("selection-container", true);
 
-      var select = selectionContainersEnter.append("select")
-        .on('change', function(index) {
-          var selectedRun = select.property('value');
-          if (selectedRun !== NONE_SELECTION) {
-            selectedRun = parseInt(selectedRun);
-          }
-          state.selectedRuns[index] = selectedRun;
-          render();
-        });
+      selectionContainersEnter.append("select")
+        .on('change', changeSelectedChart);
 
       selectionContainersEnter.append("a")
-        .classed("compare-responses", true).text("Compare responses").on("click", function() {
-          state.selectedRuns = [state.selectedRuns[0], NONE_SELECTION];
-          render();
-        });
+        .classed("compare-responses", true)
+        .text("Compare responses")
+        .on("click", openNewChart);
 
       selectionContainersEnter.append("a")
-        .classed("close", true).text("Close ").on('click', function(index) {
-          state.selectedRuns.splice(index, 1);
-          render();
-        }).append("span").attr("class", "fa fa-close");
+        .classed("close", true)
+        .text("Close ")  // trailing space is intentional, CSS will add a 'X' right after
+        .on('click', closeChart)
+        .append("span")
+        .attr("class", "fa fa-close");
 
       var selectionRowsMerged = selectionContainersEnter.merge(selectionContainers);
       selectionRowsMerged.selectAll(".compare-responses").classed("hidden", function() {

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -266,9 +266,11 @@
 
       // Create x scale to map answer ids to bar x coordinate locations. Note that
       // histogram was previously sorted in order of the lowercase answer id.
-      var x = d3.scaleBand().rangeRound([0, ChartSettings.width / state.selectedRuns.length]).padding(0.1).domain(
-        histogramAnswerIds
-      );
+      var x = d3.scaleBand()
+        .rangeRound([0, ChartSettings.width / state.selectedRuns.length])
+        .padding(0.1)
+        .domain(histogramAnswerIds);
+
       // Create y scale to map response count to y coordinate for the top of the bar.
       var y = d3.scaleLinear().rangeRound([ChartSettings.height, 0]).domain(
         // pick the maximum count so we know how high the bar chart should go

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -140,9 +140,10 @@
       var chartKeys = _.keys(state.selectedRuns);
 
       // D3 data join for charts. Create a container div for each chart to store graph, select element and buttons.
-      var containers = d3.select(element).select(
-        rapidBlockResultsSel
-      ).selectAll(".chart-container").data(chartKeys);
+      var containers = d3.select(element)
+        .select(rapidBlockResultsSel)
+        .selectAll(".chart-container")
+        .data(chartKeys);
       var containersEnter = containers.enter()
         .append("div");
 
@@ -332,7 +333,6 @@
           var answerText = response ? response.answer_text : "";
           wrapText(d3.select(nodes[i]), x.bandwidth(), answerText);
         });
-
 
       // Update the Y axis.
       // By default it assumes a continuous scale, but we just want to show integers so we need to create the ticks

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -52,8 +52,7 @@
       $rapidBlockContent.find(problemStatusBtnSel).click(function() {
         $.post(toggleStatusUrl).then(
           function(newState) {
-            // if the button to toggle this is visible there should only be one chart, so
-            // selectedRuns just replaces the existing one
+            // Selected runs should be reset when the open status is changed
             state = _.assign({}, state, newState, {
               selectedRuns: [null]
             });

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -148,12 +148,12 @@
         .append("div");
 
       // chart selection, close and compare buttons
-      var selectionRows = containers.selectAll(".selection-row");
-      var selectionRowsEnter = containersEnter
+      var selectionContainers = containers.selectAll(".selection-container");
+      var selectionContainersEnter = containersEnter
         .append("div")
-        .classed("selection-row", true);
+        .classed("selection-container", true);
 
-      var select = selectionRowsEnter.append("select")
+      var select = selectionContainersEnter.append("select")
         .on('change', function(index) {
           var selectedRun = select.property('value');
           if (selectedRun !== NONE_SELECTION) {
@@ -163,19 +163,19 @@
           render();
         });
 
-      selectionRowsEnter.append("a")
+      selectionContainersEnter.append("a")
         .classed("compare-responses", true).text("Compare responses").on("click", function() {
           state.selectedRuns = [state.selectedRuns[0], NONE_SELECTION];
           render();
         });
 
-      selectionRowsEnter.append("a")
+      selectionContainersEnter.append("a")
         .classed("close", true).text("Close ").on('click', function(index) {
           state.selectedRuns.splice(index, 1);
           render();
         }).append("span").attr("class", "fa fa-close");
 
-      var selectionRowsMerged = selectionRowsEnter.merge(selectionRows);
+      var selectionRowsMerged = selectionContainersEnter.merge(selectionContainers);
       selectionRowsMerged.selectAll(".compare-responses").classed("hidden", function() {
         return chartKeys.length !== 1 || state.is_open || state.runs.length < 2;
       });
@@ -221,7 +221,7 @@
       var selectedRun = state.selectedRuns[chartIndex];
 
       // select the proper option and use it to filter the runs
-      var select = container.select(".selection-row").select("select")
+      var select = container.select(".selection-container").select("select")
         .classed("hidden", state.runs.length === 0 || state.is_open);
       if (selectedRun === null && runs.length > 0) {
         // The newest run should be the most recent one according to the info received from the server.

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -221,7 +221,7 @@
 
       // select the proper option and use it to filter the runs
       var select = container.select(".selection-row").select("select")
-        .classed("hidden", state.runs.length === 0);
+        .classed("hidden", state.runs.length === 0 || state.is_open);
       if (selectedRun === null && runs.length > 0) {
         // The newest run should be the most recent one according to the info received from the server.
         selectedRun = runs[0].id;


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #29 

#### What's this PR do?
Add logic and UI to compare two runs

#### How should this be manually tested?
NOTE: styles still need some work, see #42 

Single graph:
 - Load page. You should see most recent graph
 - Open the problem. The graph should clear and the select should change to a new item for the current time.
 - Submit a response. It should appear in the graph soon after.
 - Switch responses. You should see the graph update.
 - Switch to 'None'. The graph should disappear. Switch to another response and the graph should show up again.

Compare responses:
 - Before you click the link select a graph
 - Click 'Compare Responses'. The graph on the left should be the same graph as the one which was there before. The graph on the right should say 'Select previous response to compare'.
 - Try switching the run for the two graphs. 
 - On the right graph click 'Close'. You should see the left graph take up the whole space just like before.
 - Click 'Compare Responses' then click 'Close' on the left graph. You should see only 'None' selected.
 - Click 'Open Problem Now'. You should see the 'Compare Responses' link disappear. Click 'Close Problem' and you should see the link reappear.
 - Click 'Compare Responses'. You should see the 'Open Problem Now' link disappear. Click one of the 'Close' buttons and the button should reappear
