### PR TITLE
Show number of students while problem is open

### DIFF
--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -126,7 +126,7 @@ class RapidResponseAside(XBlockAside):
             run = RapidResponseRun.objects.filter(
                 problem_usage_key=self.wrapped_block_usage_key,
                 course_key=self.course_key,
-            ).order_by('-created').first()
+            ).first()
 
             if run and run.open:
                 run.open = False

--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -7,7 +7,7 @@
     font-size: 14px;
 }
 
-button.problem-status-toggle {
+.problem-status-toggle {
     border-radius: 5px;
     border: 2px solid #1176b2;
     color: #1176b2;
@@ -15,14 +15,16 @@ button.problem-status-toggle {
     font-weight: 600;
     padding: 0.625rem 1rem !important;
     margin-right: 30px;
+    cursor: pointer;
 }
 
-button.problem-status-toggle:hover {
-    background: #065683 none;
-    box-shadow: none;
+.rapid-response-title {
+    display: flex;
+    flex-direction: row;
+    justify-content: space-between;
 }
 
-.rapid-response-content {
+.rapid-response-controls {
     height: 70px;
 }
 
@@ -56,10 +58,6 @@ text.message {
     padding: 0 0 20px 0;
 }
 
-.selection-container {
-    font-size: 14pt;
-}
-
 .buttons-row {
     display: flex;
     flex-direction: row;
@@ -74,6 +72,10 @@ text.message {
     margin-right: 30px;
 }
 
+.timer.on {
+    color: black;
+}
+
 .timer-spinner {
     color: #1aafdd;
     font-size: 35pt;
@@ -82,6 +84,10 @@ text.message {
 .timer-spinner-text {
     color: #1aafdd;
     margin-left: 20px;
+}
+
+.selection-container {
+    font-size: 14pt;
 }
 
 .selection-container a {
@@ -109,4 +115,8 @@ text.message {
 
 .xblock {
     max-width: inherit !important;
+}
+
+.num-students {
+    font-size: 14pt;
 }

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -1,9 +1,14 @@
 <div class="rapid-response-block" data-open="{{ is_open }}">
-  <h3 class="chart-title">Live Response</h3>
-  <div class="rapid-response-content">
+  <div class="rapid-response-title">
+    <h3 class="chart-title">Live Response</h3>
+    <div class="num-students">
+    </div>
+  </div>
+
+  <div class="rapid-response-controls">
     <div class="buttons-row hidden">
-      <button class="btn btn-brand problem-status-toggle">
-      </button>
+      <a class="problem-status-toggle">
+      </a>
       <div class="timer">
       </div>
       <div class="timer-spinner fa fa-spinner fa-pulse fa-spin hidden">
@@ -15,7 +20,6 @@
   </div>
   <div class="rapid-response-results-container">
     <div class="rapid-response-results">
-
     </div>
   </div>
 </div>

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -132,7 +132,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         assert RapidResponseRun.objects.filter(
             problem_usage_key=usage_key,
             course_key=course_key,
-            open=True
+            open=True,
         ).exists() is True
 
     def test_toggle_block_open_duplicate(self):
@@ -331,12 +331,12 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         run1 = RapidResponseRun.objects.create(
             course_key=course_id,
             problem_usage_key=problem_id,
-            open=False
+            open=False,
         )
         run2 = RapidResponseRun.objects.create(
             course_key=course_id,
             problem_usage_key=problem_id,
-            open=True
+            open=True,
         )
 
         assert RapidResponseAside.serialize_runs([run2, run1]) == [{


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #36


#### What's this PR do?
 - Adds a column to store the number of enrolled students at the time a problem was opened
 - Pass this information to the frontend. It will use the number of submissions and this to show a message to a staff user regarding the number of responses currently. The options in the run switcher will also now show this information for each run.

Note that existing runs will show 0 enrolled students, only new runs will have an accurate enrolled student count.

#### How should this be manually tested?
Open a new problem and submit a response. It should show 1 response in the text and some number of enrolled users. Close the problem and note that the select element has the new run with 1 response in the text. 
