### PR TITLE
Fix handling of multiple runs which are open

### DIFF
--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -160,7 +160,7 @@ class RapidResponseAside(XBlockAside):
         run_querysets = RapidResponseRun.objects.filter(
             problem_usage_key=self.wrapped_block_usage_key,
             course_key=self.course_key,
-        ).order_by('-created')
+        )
         runs = self.serialize_runs(run_querysets)
         # Only the most recent run should possibly be open
         # If other runs are marked open due to some race condition, look at only the first.

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -128,15 +128,15 @@ class RapidResponseAside(XBlockAside):
                 course_key=self.course_key,
             ).order_by('-created').first()
 
-            if not run or run.open is False:
+            if run and run.open:
+                run.open = False
+                run.save()
+            else:
                 run = RapidResponseRun.objects.create(
                     problem_usage_key=self.wrapped_block_usage_key,
                     course_key=self.course_key,
                     open=True,
                 )
-            else:
-                run.open = False
-                run.save()
         return Response(
             json_body={
                 'is_open': run.open,

--- a/rapid_response_xblock/logger.py
+++ b/rapid_response_xblock/logger.py
@@ -82,10 +82,9 @@ class SubmissionRecorder(BaseBackend):
 
         open_run = RapidResponseRun.objects.filter(
             problem_usage_key=sub.problem_usage_key,
-            course_key=sub.course_key,
-            open=True
-        ).first()
-        if not open_run:
+            course_key=sub.course_key
+        ).order_by('-created').first()
+        if not open_run or not open_run.open:
             # Problem is not open
             return
 

--- a/rapid_response_xblock/models.py
+++ b/rapid_response_xblock/models.py
@@ -26,6 +26,9 @@ class RapidResponseRun(models.Model):
     created = models.DateTimeField(auto_now_add=True, db_index=True)
     modified = models.DateTimeField(auto_now=True)
 
+    class Meta:
+        ordering = ['-created']
+
     def __str__(self):
         return (
             "id={id} created={created} problem_usage_key={problem_usage_key} "

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -56,6 +56,20 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         assert bool(fragment.content) is should_render_aside
         assert (fragment.js_init_fn == 'RapidResponseAsideInit') is should_render_aside
 
+    @data(True, False)
+    def test_student_view_context(self, is_open):
+        """
+        Test that the aside student view has the proper context variables
+        """
+        self.aside_instance.enabled = True
+        with patch(
+            'rapid_response_xblock.block.RapidResponseAside.has_open_run',
+            new_callable=PropertyMock,
+        ) as has_open_run_mock:
+            has_open_run_mock.return_value = is_open
+            fragment = self.aside_instance.student_view_aside(Mock())
+        assert 'data-open="{}"'.format(is_open) in fragment.content
+
     @data(*[
         [BLOCK_PROBLEM_CATEGORY, {MULTIPLE_CHOICE_TYPE}, None, True],
         [BLOCK_PROBLEM_CATEGORY, None, Mock(problem_types={MULTIPLE_CHOICE_TYPE}), True],
@@ -120,6 +134,28 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             course_key=course_key,
             open=True
         ).exists() is True
+
+    def test_toggle_block_open_duplicate(self):
+        """Test that toggle_block_open_status only looks at the last run's open status"""
+        usage_key = self.aside_instance.wrapped_block_usage_key
+        course_key = self.aside_instance.course_key
+        RapidResponseRun.objects.create(
+            problem_usage_key=usage_key,
+            course_key=course_key,
+            open=True,
+        )
+        RapidResponseRun.objects.create(
+            problem_usage_key=usage_key,
+            course_key=course_key,
+            open=False,
+        )
+
+        self.aside_instance.toggle_block_open_status(Mock())
+        assert RapidResponseRun.objects.count() == 3
+        assert RapidResponseRun.objects.filter(
+            problem_usage_key=usage_key,
+            course_key=course_key,
+        ).order_by('-created').first().open is True
 
     def test_toggle_block_enabled(self):
         """

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -241,7 +241,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             get_choices_mock.return_value = choices
             resp = self.aside_instance.responses()
 
-        run_queryset = RapidResponseRun.objects.order_by('-created')
+        run_queryset = RapidResponseRun.objects.all()
         assert resp.status_code == 200
         assert resp.json['is_open'] is has_runs
 

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -258,3 +258,19 @@ class TestEvents(RuntimeEnabledTestCase):
         assert RapidResponseSubmission.objects.count() == 1
         submission = RapidResponseSubmission.objects.first()
         assert submission.event['test_data'] == event_during['test_data']
+
+    @pytest.mark.usefixtures("example_event")
+    def test_last_open(self):
+        """
+        Only the last run should be considered
+        """
+        RapidResponseRun.objects.create(
+            problem_usage_key=self.example_status.problem_usage_key,
+            course_key=self.example_status.course_key,
+            open=False,
+        )
+
+        recorder = SubmissionRecorder()
+        recorder.send(self.example_event)
+        # The last run has open=False so no submissions should be recorded
+        assert RapidResponseSubmission.objects.count() == 0


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #55 

#### What's this PR do?
Fixes handling of multiple runs which are open by only considering the latest created one

#### How should this be manually tested?
Set some existing run in the past to `open=True` via the database. On master you should get a 500 error when clicking the toggle open status button. On this PR it should show up as not being open and clicking the button should work fine.