### PR TITLE
Fixed UI to behave more reliably when server is under heavy load

### DIFF
--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -7,6 +7,12 @@
     font-size: 14px;
 }
 
+.problem-status-toggle,
+.timer-readout,
+.problem-status-text {
+    margin-right: 30px;
+}
+
 .problem-status-toggle {
     border-radius: 5px;
     border: 2px solid #1176b2;
@@ -14,7 +20,6 @@
     background: transparent;
     font-weight: 600;
     padding: 0.625rem 1rem !important;
-    margin-right: 30px;
     cursor: pointer;
 }
 
@@ -31,7 +36,8 @@
 }
 
 .rapid-response-controls {
-    height: 70px;
+    min-height: 70px;
+    padding-bottom: 10px;
 }
 
 .tick text {
@@ -64,31 +70,39 @@ text.message {
     padding: 0 0 20px 0;
 }
 
-.buttons-row {
+.buttons-row, .problem-status-warning {
     display: flex;
     flex-direction: row;
     align-items: center;
 }
 
-.timer {
+.timer-readout {
     font-size: 15pt;
     color: #7a7a7a;
     background-color: #f0f0f0;
     padding: 10px;
-    margin-right: 30px;
 }
 
-.timer.on {
+.timer-readout.on {
     color: black;
 }
 
-.timer-spinner {
-    color: #1aafdd;
+.problem-status-spinner,
+.problem-status-warning .warning-icon {
     font-size: 35pt;
 }
 
-.timer-spinner-text {
+.problem-status-spinner,
+.problem-status-text {
     color: #1aafdd;
+}
+
+.problem-status-warning {
+    color: rgb(212, 64, 64); /* $danger-red from LMS */
+}
+
+.problem-status-text,
+.problem-status-warning .warning-text {
     margin-left: 20px;
 }
 

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -9,12 +9,15 @@
     <div class="buttons-row hidden">
       <a class="problem-status-toggle">
       </a>
-      <div class="timer">
+      <div class="timer-readout">
       </div>
-      <div class="timer-spinner fa fa-spinner fa-pulse fa-spin hidden">
+      <div class="problem-status-spinner fa fa-spinner fa-pulse fa-spin hidden">
       </div>
-      <div class="timer-spinner-text hidden">
-        Problem is Open
+      <div class="problem-status-text hidden">
+      </div>
+      <div class="problem-status-warning hidden">
+        <div class="warning-icon fa fa-warning"></div>
+        <div class="warning-text"></div>
       </div>
     </div>
   </div>


### PR DESCRIPTION
#### What are the relevant tickets?
Closes #63 

#### What's this PR do?
What the PR title says.

#### How should this be manually tested?
This will be a little bit complicated, and will probably involve running the load test. Come chat with me about this

#### Any background context you want to provide?
A note about why this PR is so big: All of the UI code up until now did not account for any kind of HTTP request error (timeouts most notably), and therefore we were able to assume a very simplistic UI state of "open" or "closed". In reality, any one of the HTTP requests can experience an error (timeouts under heavy load are easily reproduceable). Handling those errors, informing the user about delays, and properly controlling the dispatching of requests meant that a significant chunk of the front end logic had to be rewritten.

#### Screenshots (if appropriate)

*Initial load*

![ss 2018-07-24 at 09 59 43](https://user-images.githubusercontent.com/14932219/43149432-635e761e-8f35-11e8-96a4-61e51638abe1.png)

*Opening (before the toggle status endpoint returns a response)*

![ss 2018-07-24 at 10 01 04](https://user-images.githubusercontent.com/14932219/43149449-6b583c4c-8f35-11e8-9048-e7f04fa1dc35.png)

*Closing  (before the toggle status endpoint returns a response)*

![ss 2018-07-24 at 10 01 32](https://user-images.githubusercontent.com/14932219/43149475-7c7da7a0-8f35-11e8-819f-a8f3fa09c1da.png)

*Closing  (after the toggle status endpoint returns a response)*

![ss 2018-07-24 at 10 02 05](https://user-images.githubusercontent.com/14932219/43149527-99969310-8f35-11e8-94de-08774ae6d7cc.png)

*Delayed response warning (while polling the responses endpoint)*

![ss 2018-07-24 at 10 27 54](https://user-images.githubusercontent.com/14932219/43149590-c51febda-8f35-11e8-901f-ed34cadafa24.png)

*Timeout (while polling the responses endpoint)*

![ss 2018-07-24 at 17 00 05](https://user-images.githubusercontent.com/14932219/43166128-c1ff611e-8f63-11e8-9e42-f2f04f0a191c.png)

*Timeout (after clicking to change the problem status, or on initial page load)*

![ss 2018-07-24 at 10 12 30](https://user-images.githubusercontent.com/14932219/43149564-b4b708be-8f35-11e8-9e22-f0651e6ecb9c.png)



