### PR TITLE
 Added general error message overlay when HTTP requests fail

### DIFF
--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -1,4 +1,5 @@
 .rapid-response-block {
+    position: relative;
     background-color: #f7f7f7;
     padding: 30px;
 }
@@ -164,4 +165,20 @@ text.message {
 
 .rapid-response-tooltip .tooltip-percent, .rapid-response-tooltip .tooltip-total {
     font-weight: 600;
+}
+
+.rapid-response-block .rapid-response-error-overlay {
+    position : absolute;
+    z-index : 10;
+    top : 0;
+    left : 0;
+    width: 100%;
+    height: 100%;
+    background: #000;
+    opacity: 0.7;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-size: 1.5rem;
+    color: #fff;
 }

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -24,4 +24,6 @@
   <div class="rapid-response-results-container">
     <div class="rapid-response-results"></div>
   </div>
+  <div class="rapid-response-error-overlay hidden">
+  </div>
 </div>


### PR DESCRIPTION
#### What are the relevant tickets?
⚠️ REBASED ON #64 ⚠️ 
Closes #58 

#### What's this PR do?
What the title says

#### How should this be manually tested?
Replace any of the HTTP request URLs in `rapid.js` to `https://httpbin.org/status/400`

#### Screenshots (if appropriate)
![ss 2018-07-24 at 12 43 26](https://user-images.githubusercontent.com/14932219/43153598-b02dcac6-8f3f-11e8-8159-f3777bdf7b03.png)
