### PR TITLE
Applied MathJax to graph and tooltip

### DIFF
--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -6,7 +6,7 @@ source /edx/app/edxapp/venvs/edxapp/bin/activate
 cd /edx/app/edxapp/edx-platform
 mkdir -p reports
 
-pip install -r ./requirements/edx/testing.in
+pip install -r ./requirements/edx/testing.txt
 
 cd /rapid-response-xblock
 pip install -e .
@@ -21,13 +21,13 @@ mkdir -p test_root  # for edx
 
 set +e
 
-# We're running pep8 directly here since pytest-pep8 hasn't been updated in a while and has a bug
+# We're running pycodestyle directly here since pytest-pep8 hasn't been updated in a while and has a bug
 # linting this project's code. pylint is also run directly since it seems cleaner to run them both
 # separately than to run one as a plugin and one by itself.
 pytest tests --cov .
 PYTEST_SUCCESS=$?
-pep8 rapid_response_xblock tests
-PEP8_SUCCESS=$?
+pycodestyle rapid_response_xblock tests
+PYCODESTYLE_SUCCESS=$?
 (cd /edx/app/edxapp/edx-platform; pylint /rapid-response-xblock/rapid_response_xblock /rapid-response-xblock/tests)
 PYLINT_SUCCESS=$?
 
@@ -36,10 +36,10 @@ then
     echo "pytest exited with a non-zero status"
     exit $PYTEST_SUCCESS
 fi
-if [[ $PEP8_SUCCESS -ne 0 ]]
+if [[ $PYCODESTYLE_SUCCESS -ne 0 ]]
 then
-    echo "pep8 exited with a non-zero status"
-    exit $PEP8_SUCCESS
+    echo "pycodestyle exited with a non-zero status"
+    exit $PYCODESTYLE_SUCCESS
 fi
 if [[ $PYLINT_SUCCESS -ne 0 ]]
 then

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/env
 python_classes =
 python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py
 
-[pep8]
+[pycodestyle]
 # error codes: http://pep8.readthedocs.org/en/latest/intro.html#error-codes
 # E501: line too long
 # E265: block comment should start with ‘# ‘
@@ -44,7 +44,7 @@ python_files = tests.py test_*.py tests_*.py *_tests.py __init__.py
 #   http://nedbatchelder.com/blog/200711/rethrowing_exceptions_in_python.html
 #   It's a little unusual, but we have good reasons for doing so, so we disable
 #   this rule.
-ignore=E501,E265,W602
+ignore=E501,E265,W602,E722
 exclude=migrations,.git,.pycharm_helpers,.tox,test_root/staticfiles,node_modules
 
 [isort]


### PR DESCRIPTION
#### What are the relevant tickets?
fixes https://github.com/mitodl/rapid-response-xblock/issues/68

#### What's this PR do?
Adds mathjax rendering on equations

#### How should this be manually tested?
Test everything working on xblock

**Sample Problem**
```
<problem url_name="CQ1_R06_Q5">
  <p>Consider the bar in the figure below. The bar has a uniform cross sectional area \(A_0\) and is composed of linear elastic material with modulus \(E\).  Which is a valid expression for the displacement field along the bar?</p>
  <center>
    <img src="/static/images/A02C_01_04.png" width="60%"/>
  </center>
  <multiplechoiceresponse direction="vertical">
    <choicegroup type="MultipleChoice">
      <choice location="bottom" correct="false"> (a) \(u(x) = \int_{0}^{x}{\varepsilon(x')dx'}\) </choice>
      <choice location="bottom" correct="true"> (b) \(u(x) =  \int_{L}^{x}{\varepsilon(x')dx'}\) </choice>
      <choice location="bottom" correct="false"> (c) \(u(x) = \frac{PL}{EA_0} \) </choice>
      <choice location="bottom" correct="false"> (d) \(u(x) = -\frac{PL}{EA_0} \) </choice>
    </choicegroup>
  </multiplechoiceresponse>
  <solution>
    <div class="detailed-solution">
      <p>Explanation</p>
      <p> \((b)\) is the only correct one : \(u(x) = u(x=L) + \int_{L}^{x}{\varepsilon(x')dx'}\), but \(u(L)=0\). </p>
      <p> (\(a\)) neglects the nonzero displacement at \(x = 0\). It is correct to write: \(u(x) = u(x=0) + \int_{0}^{x}{\varepsilon(x')dx'}\), but \(u(x=0)\) for this problem is not zero.</p>
      <p> \((c)\) and  \((d)\) are wrong. The displacement field is not a constant. A constant (uniform) displacement field corresponds to a rigid translation of the bar. Note that the elongation of the bar is \(\delta=\frac{PL}{EA_0}\), while the displacement at the free end is \(u_x(0)= -\frac{PL}{EA_0} \) </p>
    </div>
  </solution>
</problem>
```

#### Screenshots (if appropriate)
<img width="946" alt="screen shot 2018-11-29 at 5 39 55 pm" src="https://user-images.githubusercontent.com/10431250/49222553-f48da880-f3fd-11e8-8cf4-3d13274de12d.png">

![screen shot 2018-11-29 at 5 40 04 pm](https://user-images.githubusercontent.com/10431250/49222555-f5263f00-f3fd-11e8-8c14-5281c7494766.png)



