### PR TITLE
Util methods added in xblock to serve instructor dashboard

### DIFF
--- a/rapid_response_xblock/utils.py
+++ b/rapid_response_xblock/utils.py
@@ -1,0 +1,24 @@
+"""Utils methods for instructor dashboard"""
+
+from rapid_response_xblock.models import RapidResponseRun, RapidResponseSubmission
+
+
+def get_run_data_for_course(course_key):
+    """Util method to return problem runs corresponding to given course key"""
+    return RapidResponseRun.objects.filter(course_key=course_key).values('id', 'created', 'problem_usage_key')
+
+
+def get_run_submission_data(run_id):
+    """
+    Return data required to generate csv file corresponding to given run_id
+    """
+    submissions = RapidResponseSubmission.objects.filter(run_id=run_id)
+    return [
+        [s.created, s.answer_text, s.user.username, s.user.email, get_answer_result(s.event)]
+        for s in submissions
+    ]
+
+
+def get_answer_result(event):
+    # TODO find better way if we can
+    return event['event']['submission'].values()[0]['correct']

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,54 @@
+"""Tests for the util methods"""
+from opaque_keys.edx.keys import UsageKey
+from student.tests.factories import UserFactory
+
+
+from rapid_response_xblock.models import RapidResponseRun, RapidResponseSubmission
+from rapid_response_xblock.utils import get_run_data_for_course, get_run_submission_data
+from tests.utils import RuntimeEnabledTestCase
+
+
+class TestUtils(RuntimeEnabledTestCase):
+    """Utils method tests"""
+
+    def setUp(self):
+        super(TestUtils, self).setUp()
+        self.problem_run = RapidResponseRun.objects.create(
+            problem_usage_key=UsageKey.from_string("i4x://SGAU/SGA101/problem/2582bbb68672426297e525b49a383eb8"),
+            course_key=self.course_id,
+            open=True,
+        )
+
+    def test_get_run_data_for_course(self):
+        """Verify that method returns list fo dicts with required fields."""
+        expected = [
+            {
+                'id': self.problem_run.id,
+                'created': self.problem_run.created,
+                'problem_usage_key': self.problem_run.problem_usage_key
+            }
+        ]
+
+        problem_runs = get_run_data_for_course(self.course_id)
+        assert list(problem_runs) == expected
+
+    def test_get_run_submission_data(self):
+        user = UserFactory()
+        answer = "false"
+        event_data = {
+            "event": {
+                "submission": {
+                    "123456": {
+                        "correct": answer,
+                    }
+                }
+            }
+        }
+
+        submission = RapidResponseSubmission.objects.create(run=self.problem_run, user=user, event=event_data)
+        expected = [[
+            submission.created, submission.answer_text, submission.user.username, submission.user.email, answer
+        ]]
+        submissions_data = get_run_submission_data(self.problem_run.id)
+
+        assert submissions_data == expected


### PR DESCRIPTION
#### What are the relevant tickets?
Fixes #71 

#### What's this PR do?
add util methods to get rapid response data to show in instructor dashboard.

#### How should this be manually tested?
For setting up locally please see https://github.com/mitodl/rapid-response-xblock/blob/master/README.md

#### Any background context you want to provide?
These methods will be used in https://github.com/mitodl/edx-platform/pull/108