### PR TITLE
Fixed index out of bound error in case of no submission data

### DIFF
--- a/rapid_response_xblock/logger.py
+++ b/rapid_response_xblock/logger.py
@@ -48,13 +48,13 @@ class SubmissionRecorder(BaseBackend):
         # Ignore if this event was not the submission of an answer
         if event.get('name') != 'problem_check':
             return None
-        # Ignore if there were multiple submissions represented in this single event
+        # Ignore if there were multiple or no submissions represented in this single event
         event_data = event.get('data')
         if not event_data or not isinstance(event_data, dict):
             return None
 
         event_submissions = event_data.get('submission')
-        if len(event_submissions) > 1:
+        if len(event_submissions) != 1:
             return None
 
         submission_key, submission = list(event_submissions.items())[0]


### PR DESCRIPTION
#### What are the relevant tickets?
#92 

#### What's this PR do?
Fixes an Index related error that occurred in case there are no submissions in the event.

#### How should this be manually tested?
Open a problem, Try to generate an event without any submission data in it.

#### Where should the reviewer start?
(Optional)

#### Any background context you want to provide?
- You can have a look at some previous PRs in which we had to changes the implementation since the event structure from edX was changed (https://github.com/mitodl/rapid-response-xblock/pull/86, https://github.com/mitodl/rapid-response-xblock/pull/90)
