### PR TITLE
Lilac Compatibility: Fix and run tests on Lilac release of edX

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,6 @@ jobs:
           cd ../edx-platform
           git remote add mitodl https://github.com/mitodl/edx-platform.git
           git fetch mitodl
-          git checkout mitodl/mitx/koa
+          git checkout mitodl/mitx/lilac
           cd ../devstack
           DEVSTACK_WORKSPACE=$PWD/.. docker-compose -f docker-compose.yml -f docker-compose-host.yml run -v $PWD/../rapid-response-xblock:/rapid-response-xblock lms /rapid-response-xblock/run_devstack_integration_tests.sh

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -118,7 +118,7 @@ class RapidResponseAside(XBlockAside):
 
     @XBlock.handler
     @staff_only
-    def toggle_block_open_status(self, request=None, suffix=None):
+    def toggle_block_open_status(self, request=None, suffix=None):  # pylint: disable=unused-argument
         """
         Toggles the open/closed status for the rapid-response-enabled block
         """
@@ -144,7 +144,7 @@ class RapidResponseAside(XBlockAside):
         )
 
     @XBlock.handler
-    def toggle_block_enabled(self, request=None, suffix=None):
+    def toggle_block_enabled(self, request=None, suffix=None):  # pylint: disable=unused-argument
         """
         Toggles the enabled status for the rapid-response-enabled block
         """
@@ -153,7 +153,7 @@ class RapidResponseAside(XBlockAside):
 
     @XBlock.handler
     @staff_only
-    def responses(self, request=None, suffix=None):
+    def responses(self, request=None, suffix=None):  # pylint: disable=unused-argument
         """
         Returns student responses for rapid-response-enabled block
         """

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,19 +25,23 @@ addopts = --nomigrations --reuse-db --durations=20
 # and field_data deprecation warnings (because fixing them requires a major low-priority refactoring)
 filterwarnings =
     default
-    ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore::xblock.exceptions.FieldDataDeprecationWarning
+    ignore::django.utils.deprecation.RemovedInDjango31Warning
+    ignore::django.utils.deprecation.RemovedInDjango30Warning
+    ignore::pytest.PytestConfigWarning
+    ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore:Flags not at the start of the expression:DeprecationWarning
     ignore:Using or importing the ABCs from 'collections' instead of from 'collections.abc':DeprecationWarning
-    ignore::import_shims.warn.DeprecatedEdxPlatformImportWarning
     ignore:invalid escape sequence:DeprecationWarning
     ignore:`formatargspec` is deprecated since Python 3.5:DeprecationWarning
     ignore:the imp module is deprecated in favour of importlib:DeprecationWarning
-    ignore::pytest.PytestConfigWarning
     ignore:"is" with a literal:SyntaxWarning
     ignore:defusedxml.lxml is no longer supported:DeprecationWarning
-    ignore::django.utils.deprecation.RemovedInDjango31Warning
-    ignore::django.utils.deprecation.RemovedInDjango30Warning
+    ignore: `np.int` is a deprecated alias for the builtin `int`.:DeprecationWarning
+    ignore: `np.float` is a deprecated alias for the builtin `float`.:DeprecationWarning
+    ignore: `np.complex` is a deprecated alias for the builtin `complex`.:DeprecationWarning
+    ignore: 'etree' is deprecated. Use 'xml.etree.ElementTree' instead.:DeprecationWarning
+
 junit_family = xunit2
 norecursedirs = .* *.egg build conf dist node_modules test_root cms/envs lms/envs
 python_classes =

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -28,7 +28,7 @@ from common.djangoapps.student.tests.factories import UserFactory
 class RapidResponseAsideTests(RuntimeEnabledTestCase):
     """Tests for RapidResponseAside logic"""
     def setUp(self):
-        super(RapidResponseAsideTests, self).setUp()
+        super().setUp()
         self.aside_usage_key = UsageKey.from_string(
             "aside-usage-v2:block-v1$:SGAU+SGA101+2017_SGA+type@problem+block"
             "@2582bbb68672426297e525b49a383eb8::rapid_response_xblock"

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -28,7 +28,7 @@ class TestEvents(RuntimeEnabledTestCase):
     """Tests for event capturing"""
 
     def setUp(self):
-        super(TestEvents, self).setUp()
+        super().setUp()
         self.scope_ids = make_scope_ids(self.runtime, self.descriptor)
 
         # For the test_data course

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,7 +12,7 @@ class TestUtils(RuntimeEnabledTestCase):
     """Utils method tests"""
 
     def setUp(self):
-        super(TestUtils, self).setUp()
+        super().setUp()
         self.problem_run = RapidResponseRun.objects.create(
             problem_usage_key=UsageKey.from_string("i4x://SGAU/SGA101/problem/2582bbb68672426297e525b49a383eb8"),
             course_key=self.course_id,

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,7 +64,7 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
     commonly-needed objects for testing XBlocks
     """
     def setUp(self):
-        super(RuntimeEnabledTestCase, self).setUp()
+        super().setUp()
         self.track_function = make_track_function(HttpRequest())
         self.student_data = Mock()
         self.course = self.import_test_course()


### PR DESCRIPTION
#### What are the relevant tickets?
#100 

#### What's this PR do?
Updates the CI to run tests on the `Lilac` release of edX instead of `Koa`.

#### How should this be manually tested?
- A general look at the tests and checking that they are passing
