### PR TITLE
chore: add support for Django3.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           cd ../edx-platform
           git remote add mitodl https://github.com/mitodl/edx-platform.git
           git fetch mitodl
-          git checkout mitodl/mitx/lilac
+          git checkout master
           cd ../devstack
           DEVSTACK_WORKSPACE=$PWD/.. docker-compose -f docker-compose.yml -f docker-compose-host.yml run -v $PWD/../rapid-response-xblock:/rapid-response-xblock lms /rapid-response-xblock/run_devstack_integration_tests.sh
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,14 @@
+coverage:
+  status:
+    project:
+      default:
+        enabled: yes
+        target: 90%
+    patch:
+      default:
+        enabled: yes
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false

--- a/rapid_response_xblock/migrations/0001_initial.py
+++ b/rapid_response_xblock/migrations/0001_initial.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.db import migrations, models
 import jsonfield.fields
 from django.conf import settings

--- a/rapid_response_xblock/migrations/0002_block_status.py
+++ b/rapid_response_xblock/migrations/0002_block_status.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.db import migrations, models
 import opaque_keys.edx.django.models
 

--- a/rapid_response_xblock/migrations/0003_rename_fields.py
+++ b/rapid_response_xblock/migrations/0003_rename_fields.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.db import migrations
 
 

--- a/rapid_response_xblock/migrations/0004_run.py
+++ b/rapid_response_xblock/migrations/0004_run.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from django.db import migrations, models
 import django.db.models.deletion
 import django.utils.timezone

--- a/rapid_response_xblock/models.py
+++ b/rapid_response_xblock/models.py
@@ -5,7 +5,7 @@ Rapid Response block models
 
 from django.conf import settings
 from django.db import models
-from django.utils.encoding import python_2_unicode_compatible
+
 from jsonfield import JSONField
 from model_utils.models import TimeStampedModel
 from opaque_keys.edx.django.models import (
@@ -14,7 +14,6 @@ from opaque_keys.edx.django.models import (
 )
 
 
-@python_2_unicode_compatible
 class RapidResponseRun(models.Model):
     """
     Stores information for a group of RapidResponseSubmission objects
@@ -42,7 +41,6 @@ class RapidResponseRun(models.Model):
         )
 
 
-@python_2_unicode_compatible
 class RapidResponseSubmission(TimeStampedModel):
     """
     Stores the student submissions for a problem that is

--- a/rapid_response_xblock/settings.py
+++ b/rapid_response_xblock/settings.py
@@ -11,3 +11,4 @@ def plugin_settings(settings):
             'name': 'rapid_response',
         }
     }
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/setup.cfg
+++ b/setup.cfg
@@ -26,8 +26,6 @@ addopts = --nomigrations --reuse-db --durations=20
 filterwarnings =
     default
     ignore::xblock.exceptions.FieldDataDeprecationWarning
-    ignore::django.utils.deprecation.RemovedInDjango31Warning
-    ignore::django.utils.deprecation.RemovedInDjango30Warning
     ignore::pytest.PytestConfigWarning
     ignore:No request passed to the backend, unable to rate-limit:UserWarning
     ignore:Flags not at the start of the expression:DeprecationWarning

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author="MITx",
     zip_safe=False,
     install_requires=[
-        'django>=2.2,<3.0',
+        'django>=2.2,<4.0',
         'XBlock',
         'xblock-utils',
         'edx-opaque-keys'

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -2,7 +2,7 @@
 from collections import defaultdict
 from datetime import datetime, timedelta
 from ddt import data, ddt, unpack
-from mock import Mock, patch, PropertyMock
+from unittest.mock import Mock, patch, PropertyMock
 
 from dateutil.parser import parse as parse_datetime
 import pytz
@@ -68,7 +68,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         ) as has_open_run_mock:
             has_open_run_mock.return_value = is_open
             fragment = self.aside_instance.student_view_aside(Mock())
-        assert 'data-open="{}"'.format(is_open) in fragment.content
+        assert f'data-open="{is_open}"' in fragment.content
 
     @data(*[
         [BLOCK_PROBLEM_CATEGORY, {MULTIPLE_CHOICE_TYPE}, None, True],
@@ -98,7 +98,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
         """
         self.aside_instance.enabled = enabled_value
         fragment = self.aside_instance.studio_view_aside(Mock())
-        assert 'data-enabled="{}"'.format(enabled_value) in fragment.content
+        assert f'data-enabled="{enabled_value}"' in fragment.content
         assert fragment.js_init_fn == 'RapidResponseAsideStudioInit'
 
     def test_toggle_block_open(self):

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -1,5 +1,5 @@
 """Just here to verify tests are running"""
-import mock
+from unittest import mock
 import pytest
 
 from ddt import data, ddt, unpack

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,7 +3,7 @@ from contextlib import contextmanager
 import os
 import shutil
 import tempfile
-from mock import Mock, patch
+from unittest.mock import Mock, patch
 
 from django.http.request import HttpRequest
 
@@ -12,7 +12,7 @@ from lms.djangoapps.courseware.module_render import (
     get_module_system_for_user,
     make_track_function,
 )
-from lms.djangoapps.courseware.tests.factories import StaffFactory
+from common.djangoapps.student.tests.factories import StaffFactory
 from common.djangoapps.student.tests.factories import AdminFactory
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase


### PR DESCRIPTION
#### What are the relevant tickets?
#110 

#### What's this PR do?
Adds support for Django3.2

#### How should this be manually tested?
- There are some specific changes required in edX platform as mentioned in the Readme as well, So you should checkout a specific branch that I created `https://github.com/mitodl/edx-platform/tree/arslan/rapid-response-inc`.
- Install this xBlock within the edx-platform
- Test it both with `django2 and 3` and make sure it works as intended having backward compatibility as well. More details can be seen in the Repo Readme.
- Verifying the points mentioned in the acceptance criteria of the ticket

#### Where should the reviewer start?
- Checking the documentation on installing the xBlock & then install it in edx-platform having Django2.

