### PR TITLE
fix: Add anchor reference to scroll to & design tweaks

### DIFF
--- a/rapid_response_xblock/static/css/rapid.css
+++ b/rapid_response_xblock/static/css/rapid.css
@@ -104,7 +104,8 @@ text.message {
 
 .problem-status-text,
 .problem-status-warning .warning-text {
-    margin-left: 20px;
+    margin-left: 10px;
+    font-size: 14px;
 }
 
 .selection-container {

--- a/rapid_response_xblock/static/html/rapid.html
+++ b/rapid_response_xblock/static/html/rapid.html
@@ -1,13 +1,13 @@
 <div class="rapid-response-block" data-open="{{ is_open }}">
   <div class="rapid-response-title">
-    <h3 class="chart-title">Live Response</h3>
+    <h3 id="rapid_response" class="chart-title">Live Response</h3>
     <div class="num-students">
     </div>
   </div>
 
   <div class="rapid-response-controls">
     <div class="buttons-row hidden">
-      <a class="problem-status-toggle">
+      <a href="#rapid_response" class="problem-status-toggle">
       </a>
       <div class="timer-readout">
       </div>

--- a/rapid_response_xblock/static/js/src/rapid.js
+++ b/rapid_response_xblock/static/js/src/rapid.js
@@ -149,8 +149,8 @@
     // TODO: These values are guesses, maybe we want to calculate based on browser width/height? Not sure
     var ChartSettings = {
       top: 50, // space for text for upper label on y axis
-      left: 50, // space for y axis
-      right: 50, // space for text to flow
+      left: 20, // space for y axis
+      right: 20, // space for text to flow
       bottom: 150, // space for x axis
       outerBufferWidth: 200, // pixels on the right and left
       outerTop: 100, // space between chart and top of container, should contain enough space for buttons


### PR DESCRIPTION
#### What are the relevant tickets?
#112 

#### What's this PR do?
- Fixes the Open/Close problem working of rapid response within the Learning MFE
- Fixes some design regressions that came in MFE

#### How should this be manually tested?
Check that the Rapid Response related functionality works fine within the Learning MFE - It would be a good idea to open a course with Multiple Choice Problem with Rapid Response enabled. Open the course in learning MFE and if you're an admin you'll see a button `Legacy Experience`(Open it in a new tab so that you can compare)

#### Where should the reviewer start?
-  Install the Rapid Response & creating a test course with multiple-choice questions enabled with Rapid Response(You can take a look at Readme)

#### Screenshots (if appropriate)
**Open Problem Within MFE (BEFORE) -- Notice Double lined text -- If timer, warning and info messages are all shown together**
![screencapture-localhost-2000-course-course-v1-Arbisoft-ARB-RR-0002-R1-block-v1-Arbisoft-ARB-RR-0002-R1-type-sequential-block-2daf3f5ea1194dc088cf89369660fc68-block-v1-Arbisoft-ARB-RR-0002-R1-type-vertical-block-44e675e69f2b41769473c24f2 (1)](https://user-images.githubusercontent.com/34372316/137361824-087aa38f-310c-4b1a-8467-fcfb9cd9ecce.png)

**Comparing Responses Within MFE (BEFORE) -- Notice Range/Date selecter getting outside the width**
![screencapture-localhost-2000-course-course-v1-Arbisoft-ARB-RR-0002-R1-block-v1-Arbisoft-ARB-RR-0002-R1-type-sequential-block-2daf3f5ea1194dc088cf89369660fc68-block-v1-Arbisoft-ARB-RR-0002-R1-type-vertical-block-44e675e69f2b41769473c24f2 (2)](https://user-images.githubusercontent.com/34372316/137361864-a0b1cda3-8eac-43e6-b0c0-2008801c80f5.png)

**Comparing Responses Within MFE (AFTER) -- Notice the Selecter inside the container**
![screencapture-localhost-2000-course-course-v1-Arbisoft-ARB-RR-0002-R1-block-v1-Arbisoft-ARB-RR-0002-R1-type-sequential-block-2daf3f5ea1194dc088cf89369660fc68-block-v1-Arbisoft-ARB-RR-0002-R1-type-vertical-block-44e675e69f2b41769473c24f2 (4)](https://user-images.githubusercontent.com/34372316/137361978-980823f7-9b8e-43ac-9ca7-46818f40ec97.png)

**Open Problem Within MFE (BEFORE) -- Single Lined Text**
![screencapture-localhost-2000-course-course-v1-Arbisoft-ARB-RR-0002-R1-block-v1-Arbisoft-ARB-RR-0002-R1-type-sequential-block-2daf3f5ea1194dc088cf89369660fc68-block-v1-Arbisoft-ARB-RR-0002-R1-type-vertical-block-44e675e69f2b41769473c24f29e5c](https://user-images.githubusercontent.com/34372316/137362018-4229e7e6-40db-42cd-a8ab-36874f0f847c.png)

_**View in Legacy Experience**_
**Comparison**
![screencapture-localhost-18000-courses-course-v1-Arbisoft-ARB-RR-0002-R1-courseware-7e8253e9363c4199bdc6aaeda82b26f0-2daf3f5ea1194dc088cf89369660fc68-1-2021-10-14-21_53_46](https://user-images.githubusercontent.com/34372316/137363426-5a572c4d-2a06-460b-8d82-18f3e5dbdf15.png)

**Open Problem**
![screencapture-localhost-18000-courses-course-v1-Arbisoft-ARB-RR-0002-R1-courseware-7e8253e9363c4199bdc6aaeda82b26f0-2daf3f5ea1194dc088cf89369660fc68-1-2021-10-14-21_58_55](https://user-images.githubusercontent.com/34372316/137363483-877b66b5-3a5e-4bda-bb23-a11d12121d39.png)

