### PR TITLE
feat: add rapid response config setting in author view

### DIFF
--- a/rapid_response_xblock/apps.py
+++ b/rapid_response_xblock/apps.py
@@ -1,11 +1,7 @@
 """AppConfig for rapid response"""
 from django.apps import AppConfig
-from openedx.core.djangoapps.plugins.constants import (
-    ProjectType,
-    SettingsType,
-    PluginSettings,
-)
-
+from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
+from edx_django_utils.plugins import PluginSettings, PluginURLs
 
 class RapidResponseAppConfig(AppConfig):
     """
@@ -20,5 +16,12 @@ class RapidResponseAppConfig(AppConfig):
                     PluginSettings.RELATIVE_PATH: 'settings'
                 },
             }
-        }
+        },
+        PluginURLs.CONFIG: {
+            ProjectType.CMS: {
+                PluginURLs.NAMESPACE: "",
+                PluginURLs.REGEX: "^toggle-rapid-response/",
+                PluginURLs.RELATIVE_PATH: "urls",
+            }
+        },
     }

--- a/rapid_response_xblock/apps.py
+++ b/rapid_response_xblock/apps.py
@@ -3,6 +3,7 @@ from django.apps import AppConfig
 from openedx.core.djangoapps.plugins.constants import ProjectType, SettingsType
 from edx_django_utils.plugins import PluginSettings, PluginURLs
 
+
 class RapidResponseAppConfig(AppConfig):
     """
     AppConfig for rapid response

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -104,34 +104,14 @@ class RapidResponseAside(XBlockAside):
         """
         Renders the aside contents for the author view
         """
-        fragment = Fragment('')
-        fragment.add_content(
-            render_template(
-                "static/html/rapid_studio.html",
-                {'is_enabled': self.enabled}
-            )
-        )
-        fragment.add_css(get_resource_bytes("static/css/rapid.css"))
-        fragment.add_javascript(get_resource_bytes("static/js/src/rapid_studio.js"))
-        fragment.initialize_js("RapidResponseAsideStudioInit")
-        return fragment
+        return self.get_studio_fragment()
 
     @XBlockAside.aside_for('studio_view')
     def studio_view_aside(self, block, context=None):  # pylint: disable=unused-argument
         """
         Renders the aside contents for the studio view
         """
-        fragment = Fragment('')
-        fragment.add_content(
-            render_template(
-                "static/html/rapid_studio.html",
-                {'is_enabled': self.enabled}
-            )
-        )
-        fragment.add_css(get_resource_bytes("static/css/rapid.css"))
-        fragment.add_javascript(get_resource_bytes("static/js/src/rapid_studio.js"))
-        fragment.initialize_js("RapidResponseAsideStudioInit")
-        return fragment
+        return self.get_studio_fragment()
 
     @XBlock.handler
     @staff_only
@@ -224,6 +204,22 @@ class RapidResponseAside(XBlockAside):
         # We only want this aside to apply to the block if the problem is multiple choice
         # AND there are not multiple problem types.
         return block_problem_types == {MULTIPLE_CHOICE_TYPE}
+
+    def get_studio_fragment(self):
+        """
+        Generate a Studio view based aside fragment. (Used in Studio View and Author View)
+        """
+        fragment = Fragment('')
+        fragment.add_content(
+            render_template(
+                "static/html/rapid_studio.html",
+                {'is_enabled': self.enabled}
+            )
+        )
+        fragment.add_css(get_resource_bytes("static/css/rapid.css"))
+        fragment.add_javascript(get_resource_bytes("static/js/src/rapid_studio.js"))
+        fragment.initialize_js("RapidResponseAsideStudioInit")
+        return fragment
 
     @property
     def wrapped_block_usage_key(self):

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -99,6 +99,23 @@ class RapidResponseAside(XBlockAside):
         fragment.initialize_js("RapidResponseAsideInit")
         return fragment
 
+    @XBlockAside.aside_for('author_view')
+    def author_view_aside(self, block, context=None):  # pylint: disable=unused-argument
+        """
+        Renders the aside contents for the author view
+        """
+        fragment = Fragment('')
+        fragment.add_content(
+            render_template(
+                "static/html/rapid_studio.html",
+                {'is_enabled': self.enabled}
+            )
+        )
+        fragment.add_css(get_resource_bytes("static/css/rapid.css"))
+        fragment.add_javascript(get_resource_bytes("static/js/src/rapid_studio.js"))
+        fragment.initialize_js("RapidResponseAsideStudioInit")
+        return fragment
+
     @XBlockAside.aside_for('studio_view')
     def studio_view_aside(self, block, context=None):  # pylint: disable=unused-argument
         """

--- a/rapid_response_xblock/static/js/src/rapid_studio.js
+++ b/rapid_response_xblock/static/js/src/rapid_studio.js
@@ -2,7 +2,12 @@
   'use strict';
 
   function RapidResponseAsideStudioView(runtime, element) {
-    var toggleEnabledUrl = runtime.handlerUrl(element, 'toggle_block_enabled');
+    var toggleEnabledUrl = runtime.handlerUrl(element, '');
+    // Redirect this call to our own API instead of xBlock handler because the handler callbacks are not supported
+    // for the studio preview. The calls can have two formats 1) "preview/xblock" when called from studio preview
+    // 2) "/xblock" when called from Studio plugin(Tab) settings.
+    toggleEnabledUrl = toggleEnabledUrl.replace("preview/xblock", "toggle-rapid-response")
+    toggleEnabledUrl = toggleEnabledUrl.replace("/xblock", "/toggle-rapid-response")
     var $element = $(element);
 
     var rapidTopLevelSel = '.rapid-response-block';

--- a/rapid_response_xblock/urls.py
+++ b/rapid_response_xblock/urls.py
@@ -1,0 +1,11 @@
+"""
+External checkout API endpoint urls.
+"""
+
+from django.urls import re_path
+
+from rapid_response_xblock.views import toggle_rapid_response
+
+urlpatterns = [
+    re_path(r"^", toggle_rapid_response, name="toggle_rapid_response"),
+]

--- a/rapid_response_xblock/views.py
+++ b/rapid_response_xblock/views.py
@@ -1,0 +1,51 @@
+"""Views for Rapid Response xBlock"""
+
+from django.contrib.auth.decorators import login_required
+from django.views.decorators.http import require_http_methods
+from opaque_keys.edx.keys import UsageKey
+from openedx.core.lib.xblock_utils import get_aside_from_xblock
+from xmodule.modulestore.django import modulestore
+
+from django.http import JsonResponse
+
+
+@login_required
+@require_http_methods(
+    [
+        "POST",
+    ]
+)
+def toggle_rapid_response(request):
+    """
+    An API View to toggle rapid response xblock enable status for a problem
+
+    **Example Requests**
+
+    POST:
+     toggle-rapid-response/aside-usage-v2:block-v1$:Arbisoft+ARB_RR_1+1+type@problem+block@<key>::rapid_response_xblock
+
+    **Example Responses**
+
+    The API will return two types of response codes in general
+
+    200 would be returned on successful rapid response enable status update
+
+    A 500 would be returned if there are any configuration errors or the method is not supported
+    """
+
+    if request.method != "POST":
+        raise NotImplementedError("API only supports POST requests")
+
+    block_key = request.path
+    block_key = block_key.replace("/toggle-rapid-response/", "").replace(
+        "/handler/", ""
+    )
+    usage_key = UsageKey.from_string(block_key)
+
+    block = modulestore().get_item(usage_key.usage_key)
+    handler_block = get_aside_from_xblock(block, usage_key.aside_type)
+
+    handler_block.enabled = not handler_block.enabled
+    modulestore().update_item(block, request.user.id, asides=[handler_block])
+
+    return JsonResponse({"is_enabled": handler_block.enabled})

--- a/rapid_response_xblock/views.py
+++ b/rapid_response_xblock/views.py
@@ -47,5 +47,6 @@ def toggle_rapid_response(request):
 
     handler_block.enabled = not handler_block.enabled
     modulestore().update_item(block, request.user.id, asides=[handler_block])
+    modulestore().publish(block.location, request.user.id)
 
     return JsonResponse({"is_enabled": handler_block.enabled})

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -115,6 +115,21 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             assert f'data-enabled="{enabled_value}"' in fragment.content
             assert fragment.js_init_fn == 'RapidResponseAsideStudioInit'
 
+    @data(True, False)
+    def test_author_view(self, enabled_value):
+        """
+        Test that the aside author view returns a fragment when enabled
+        """
+        self.aside_instance.enabled = enabled_value
+        with patch(
+            'rapid_response_xblock.block.RapidResponseAside.enabled',
+            new=enabled_value,
+        ):
+
+            fragment = self.aside_instance.author_view_aside(Mock())
+            assert f'data-enabled="{enabled_value}"' in fragment.content
+            assert fragment.js_init_fn == 'RapidResponseAsideStudioInit'
+
     def test_toggle_block_open(self):
         """Test that toggle_block_open_status changes the status of a rapid response block"""
         usage_key = self.aside_instance.wrapped_block_usage_key


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/hq/issues/1960 Trial of Option#1 in https://github.com/mitodl/hq/issues/1960#issuecomment-1647845771

#### What's this PR do?
- Add author view for MCQ problems
- Enables the course authors to toggle rapid response enable configuration through preview mode

#### How should this be manually tested?

- Follow the readme to install the xblock on `master` and create some rapid response MCQs to compare with this branch
- Now check out this branch:
    - Create an entry in http://localhost:18010/admin/xblock_config/studioconfig/ 
    -  And create some more MCQs or check the existing ones
    - Check that you now see an option to enable/disable rapid response for an xblock on the studio subsection preview (Check the screenshot below)
    - Check the toggle works fine on the problems without error, And on publishing it behaves as it should (e.g. Let the instructor start, stop the problem, See the responses and the bar chart for selected options)
    - Also, check that the graph doesn't show to the learner.


#### Where should the reviewer start?
- Install `rapid-response-xblock` on master, create some rapid response problems and submissions.

#### Screenshots (if appropriate)

**Studio Preview View**
<img width="1409" alt="image" src="https://github.com/mitodl/rapid-response-xblock/assets/34372316/f61e9e97-0e2f-4ea4-891b-79ef3cf19aef">

**Studio Component/Plugin/Setting View**
<img width="1713" alt="image" src="https://github.com/mitodl/rapid-response-xblock/assets/34372316/edd14f6e-42e8-4cce-b0ac-998b42abf9d7">

