### PR TITLE
fix: django 4.x support and feat flag for author view

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,10 +68,24 @@ If you're using any release before Juniper, make sure the following properties e
 
 `ADDL_INSTALLED_APPS` may include other items. The list just needs to have `rapid_response_xblock` among its values.
 
+#### Feature flags
+
+There is a feature flag to enable toggling the rapid response functionality for a problem through course outline in CMS. Enable `ENABLE_RAPID_RESPONSE_AUTHOR_VIEW` in your CMS config either through `/edx/app/edxapp/cms.env.json` or `private.py`.
+
+```yaml
+- ENABLE_RAPID_RESPONSE_AUTHOR_VIEW: true or false
+```
+
+
+__NOTE:__Once this flag is enabled and you toggle the rapid response from course outline, It will auto publish the problem if it was not in draft.
+
 ### 3) Add database record
 
 If one doesn't already exist, create a record for the `XBlockAsidesConfig` model 
 (LMS admin URL: `/admin/lms_xblock/xblockasidesconfig/`).
+
+If you have enabled `ENABLE_RAPID_RESPONSE_AUTHOR_VIEW` you will also need to create a record in the `StudioConfig` model 
+(CMS admin URL: `/admin/xblock_config/studioconfig/`).
 
 ### 4) Rapid Response for Studio and XML
 [Studio Documentation](https://odl.zendesk.com/hc/en-us/articles/360007744011-Rapid-Response-for-Studio)

--- a/rapid_response_xblock/apps.py
+++ b/rapid_response_xblock/apps.py
@@ -16,6 +16,11 @@ class RapidResponseAppConfig(AppConfig):
                 SettingsType.COMMON: {
                     PluginSettings.RELATIVE_PATH: 'settings'
                 },
+            },
+            ProjectType.CMS: {
+                SettingsType.COMMON: {
+                    PluginSettings.RELATIVE_PATH: 'cms_settings'
+                },
             }
         },
         PluginURLs.CONFIG: {

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -4,6 +4,7 @@ import logging
 from functools import wraps
 import pkg_resources
 
+from django.conf import settings
 from django.db import transaction
 from django.db.models import Count
 from django.template import Context, Template
@@ -104,7 +105,9 @@ class RapidResponseAside(XBlockAside):
         """
         Renders the aside contents for the author view
         """
-        return self.get_studio_fragment()
+        if settings.ENABLE_RAPID_RESPONSE_AUTHOR_VIEW:
+            return self.get_studio_fragment()
+        return Fragment('')
 
     @XBlockAside.aside_for('studio_view')
     def studio_view_aside(self, block, context=None):  # pylint: disable=unused-argument

--- a/rapid_response_xblock/cms_settings.py
+++ b/rapid_response_xblock/cms_settings.py
@@ -1,0 +1,10 @@
+"""Settings to provide to edX"""
+
+
+def plugin_settings(settings):
+    """
+    Populate CMS settings
+    """
+    settings.ENABLE_RAPID_RESPONSE_AUTHOR_VIEW = False
+
+DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/rapid_response_xblock/settings.py
+++ b/rapid_response_xblock/settings.py
@@ -11,4 +11,5 @@ def plugin_settings(settings):
             'name': 'rapid_response',
         }
     }
+
 DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'

--- a/setup.cfg
+++ b/setup.cfg
@@ -40,8 +40,6 @@ filterwarnings =
     ignore: `np.complex` is a deprecated alias for the builtin `complex`.:DeprecationWarning
     ignore: 'etree' is deprecated. Use 'xml.etree.ElementTree' instead.:DeprecationWarning
     ignore: defusedxml.cElementTree is deprecated, import from defusedxml.ElementTree instead.:DeprecationWarning
-    ignore: django.utils.translation.ugettext_lazy() is deprecated in favor of django.utils.translation.gettext_lazy().:django.utils.deprecation.RemovedInDjango40Warning
-    ignore: django.utils.translation.ungettext() is deprecated in favor of django.utils.translation.ngettext().:django.utils.deprecation.RemovedInDjango40Warning
 
 
 junit_family = xunit2

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setup(
     author="MITx",
     zip_safe=False,
     install_requires=[
-        'django>=2.2,<4.0',
+        'django>=2.2,<5.0',
         'XBlock',
         'xblock-utils',
         'edx-opaque-keys'


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/rapid-response-xblock/issues/143 and other changes

#### What's this PR do?
- Extends the Django version constraints to support 4.x
- Adds a feat flag to enable author view in the studio for rapid response
- fixes a bug when publishing the rapid response xblock when drafted

#### How should this be manually tested?
- Check the functionality of the newly added feat flag `ENABLE_RAPID_RESPONSE_AUTHOR_VIEW` (Check the readme for prereqs)
- Check the readme for correctness 
- Check the functionality of toggling the feat flag from outline and unit settings and it should work
- Check that installing this xBlock doesn't collide or downgrade Django 4.x to 3.x in edX
- Check that nothing else breaks and you don't see any warnings regarding the Django version since we've shifted to the major Django version (`3.x` - > `4.x`)


**NOTE:** The failing tests is a known issue and should be fixed as part of https://github.com/mitodl/rapid-response-xblock/issues/142
