### PR TITLE
fix: unable to open problem for responses

### DIFF
--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -263,7 +263,7 @@ class RapidResponseAside(XBlockAside):
         return [
             {
                 'answer_id': choice.get('name'),
-                'answer_text': list(choice.itertext())[0]}
+                'answer_text': list(choice.itertext())[0] if list(choice.itertext()) else ""}
              for choice in choice_elements
         ]
 

--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -263,8 +263,8 @@ class RapidResponseAside(XBlockAside):
         return [
             {
                 'answer_id': choice.get('name'),
-                'answer_text': choice.text,
-            } for choice in choice_elements
+                'answer_text': list(choice.itertext())[0]}
+             for choice in choice_elements
         ]
 
     @staticmethod


### PR DESCRIPTION
#### What are the relevant tickets?
#149 

#### What's this PR do?
Fixed the stuck-on-loading bug for problems created through course authoring MFE. Previously the text property of choice tree in xml was being accessed which was giving None due to the presence of xml childs(like div, code etc) inside the choice. This PR changes the `text` property to `itertext()` function that iterates through all the nodes inside the choice and returns the text in a list. 
 
#### How should this be manually tested?
1. Set up [course authoring MFE](https://github.com/openedx/frontend-app-course-authoring) as mentioned in the Readme file.
2. In Studio go to the edX Demo Course. Create a new unit which is a multiple choice problem and enable rapid response for it.
3. In LMS go to the unit you just created and click the `Open problem now` button.
4. Rapid Response is working fine now 

#### Screenshots (if appropriate)
<img width="1010" alt="Screenshot 2023-12-19 at 2 18 15 PM" src="https://github.com/mitodl/rapid-response-xblock/assets/88967643/665e8e9d-1500-425f-9c87-1a6e64b50eb9">

