### PR TITLE
Fix: Fixed the broken integration tests after the removal of old Mongo

### DIFF
--- a/rapid_response_xblock/block.py
+++ b/rapid_response_xblock/block.py
@@ -263,8 +263,9 @@ class RapidResponseAside(XBlockAside):
         return [
             {
                 'answer_id': choice.get('name'),
-                'answer_text': list(choice.itertext())[0] if list(choice.itertext()) else ""}
-             for choice in choice_elements
+                'answer_text': list(choice.itertext())[0] if list(choice.itertext()) else ""
+            }
+            for choice in choice_elements
         ]
 
     @staticmethod

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -10,7 +10,7 @@ pip install -r ./requirements/edx/testing.txt
 
 pip install -e .
 
-cd /rapid-response-xblock
+cd /edx/src/rapid-response-xblock
 pip install -e .
 
 # Install codecov so we can upload code coverage results
@@ -30,7 +30,7 @@ pytest tests --cov .
 PYTEST_SUCCESS=$?
 pycodestyle rapid_response_xblock tests
 PYCODESTYLE_SUCCESS=$?
-(cd /edx/app/edxapp/edx-platform; pylint /rapid-response-xblock/rapid_response_xblock /rapid-response-xblock/tests)
+(cd /edx/app/edxapp/edx-platform; pylint /edx/src/rapid-response-xblock/rapid_response_xblock /edx/src/rapid-response-xblock/tests)
 PYLINT_SUCCESS=$?
 
 if [[ $PYTEST_SUCCESS -ne 0 ]]

--- a/run_devstack_integration_tests.sh
+++ b/run_devstack_integration_tests.sh
@@ -10,7 +10,7 @@ pip install -r ./requirements/edx/testing.txt
 
 pip install -e .
 
-cd /edx/src/rapid-response-xblock
+cd /rapid-response-xblock
 pip install -e .
 
 # Install codecov so we can upload code coverage results
@@ -30,7 +30,7 @@ pytest tests --cov .
 PYTEST_SUCCESS=$?
 pycodestyle rapid_response_xblock tests
 PYCODESTYLE_SUCCESS=$?
-(cd /edx/app/edxapp/edx-platform; pylint /edx/src/rapid-response-xblock/rapid_response_xblock /edx/src/rapid-response-xblock/tests)
+(cd /edx/app/edxapp/edx-platform; pylint /rapid-response-xblock/rapid_response_xblock /rapid-response-xblock/tests)
 PYLINT_SUCCESS=$?
 
 if [[ $PYTEST_SUCCESS -ne 0 ]]

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -125,10 +125,10 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             'rapid_response_xblock.block.RapidResponseAside.enabled',
             new=enabled_value,
         ):
-
-            fragment = self.aside_instance.author_view_aside(Mock())
-            assert f'data-enabled="{enabled_value}"' in fragment.content
-            assert fragment.js_init_fn == 'RapidResponseAsideStudioInit'
+            with self.settings(ENABLE_RAPID_RESPONSE_AUTHOR_VIEW=True):
+                fragment = self.aside_instance.author_view_aside(Mock())
+                assert f'data-enabled="{enabled_value}"' in fragment.content
+                assert fragment.js_init_fn == 'RapidResponseAsideStudioInit'
 
     def test_toggle_block_open(self):
         """Test that toggle_block_open_status changes the status of a rapid response block"""

--- a/tests/test_aside.py
+++ b/tests/test_aside.py
@@ -34,7 +34,7 @@ class RapidResponseAsideTests(RuntimeEnabledTestCase):
             "aside-usage-v2:block-v1$:SGAU+SGA101+2017_SGA+type@problem+block"
             "@2582bbb68672426297e525b49a383eb8::rapid_response_xblock"
         )
-        self.scope_ids = make_scope_ids(self.runtime, self.aside_usage_key)
+        self.scope_ids = make_scope_ids(self.aside_usage_key)
         self.aside_instance = RapidResponseAside(
             scope_ids=self.scope_ids,
             runtime=self.runtime

--- a/tests/test_events.py
+++ b/tests/test_events.py
@@ -29,14 +29,14 @@ class TestEvents(RuntimeEnabledTestCase):
 
     def setUp(self):
         super().setUp()
-        self.scope_ids = make_scope_ids(self.runtime, self.block)
+        self.scope_ids = make_scope_ids(self.block)
         # For the test_data course
         self.test_data_status = RapidResponseRun.objects.create(
             problem_usage_key=UsageKey.from_string(
-                "i4x://SGAU/SGA101/problem/2582bbb68672426297e525b49a383eb8"
+                "block-v1:SGAU+SGA101+2017_SGA+type@problem+block@2582bbb68672426297e525b49a383eb8"
             ),
             course_key=CourseLocator.from_string(
-                'SGAU/SGA101/2017_SGA'
+                'course-v1:SGAU+SGA101+2017_SGA'
             ),
             open=True,
         )
@@ -99,7 +99,7 @@ class TestEvents(RuntimeEnabledTestCase):
         assert event['name'] == 'event_name'
         assert event['context']['event_source'] == 'server'
         assert event['data'] == event_object
-        assert event['context']['course_id'] == "{org}/{course}/{run}".format(
+        assert event['context']['course_id'] == "course-v1:{org}+{course}+{run}".format(
             org=block.location.org,
             course=block.location.course,
             run=block.location.run,
@@ -118,8 +118,7 @@ class TestEvents(RuntimeEnabledTestCase):
         problem = self.get_problem()
 
         problem.handle_ajax('problem_check', {
-            "input_i4x-SGAU-SGA101-problem-"
-            "2582bbb68672426297e525b49a383eb8_2_1": clicked_answer_id
+            "input_2582bbb68672426297e525b49a383eb8_2_1": clicked_answer_id
         })
         assert RapidResponseSubmission.objects.count() == 1
         obj = RapidResponseSubmission.objects.first()
@@ -138,8 +137,7 @@ class TestEvents(RuntimeEnabledTestCase):
         problem = self.get_problem()
         for answer in ('choice_0', 'choice_1', 'choice_2'):
             problem.handle_ajax('problem_check', {
-                "input_i4x-SGAU-SGA101-problem-"
-                "2582bbb68672426297e525b49a383eb8_2_1": answer
+                "input_2582bbb68672426297e525b49a383eb8_2_1": answer
             })
 
         assert RapidResponseSubmission.objects.count() == 1

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -9,7 +9,7 @@ from django.http.request import HttpRequest
 
 from xblock.fields import ScopeIds
 from xmodule.modulestore.django import modulestore
-from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase, TEST_DATA_MONGO_AMNESTY_MODULESTORE
+from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory
 from xmodule.modulestore.xml_importer import import_course_from_xml
 from xmodule.capa_block import ProblemBlock
@@ -24,7 +24,7 @@ from common.djangoapps.student.tests.factories import AdminFactory, StaffFactory
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 
 
-def make_scope_ids(runtime, usage_key):
+def make_scope_ids(usage_key):
     """
     Make scope ids
 
@@ -36,9 +36,8 @@ def make_scope_ids(runtime, usage_key):
         xblock.fields.ScopeIds: A ScopeIds object for the block for usage_key
     """
     block_type = 'fake'
-    def_id = runtime.id_generator.create_definition(block_type)
     return ScopeIds(
-        'user', block_type, def_id, usage_key
+        'user', block_type, "definition_id", usage_key
     )
 
 
@@ -63,20 +62,18 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
     Test class that sets up a course, instructor, runtime, and other
     commonly-needed objects for testing XBlocks
     """
-    # Using test data modulestore setting for course testing
-    MODULESTORE = TEST_DATA_MONGO_AMNESTY_MODULESTORE
 
     def setUp(self):
         super().setUp()
 
         self.track_function = make_track_function(HttpRequest())
         self.student_data = Mock()
+        self.staff = AdminFactory.create()
         self.course = self.import_test_course()
         self.block = BlockFactory(category="pure", parent=self.course)
         self.course_id = self.course.id
         self.instructor = StaffFactory.create(course_key=self.course_id)
         self.runtime = self.make_runtime()
-        self.staff = AdminFactory.create()
         self.course.bind_for_student(self.instructor)
 
     def make_runtime(self, **kwargs):
@@ -112,8 +109,9 @@ class RuntimeEnabledTestCase(ModuleStoreTestCase):
         store = modulestore()
         courses = import_course_from_xml(
             store,
-            'sga_user',
+            self.staff.id,
             xml_dir,
+            create_if_not_present=True,
         )
         return courses[0]
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -8,6 +8,8 @@ from unittest.mock import Mock, patch
 from django.http.request import HttpRequest
 
 from xblock.fields import ScopeIds
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+from xblock.test.tools import TestRuntime
 from xmodule.modulestore.django import modulestore
 from xmodule.modulestore.tests.django_utils import ModuleStoreTestCase
 from xmodule.modulestore.tests.factories import BlockFactory
@@ -19,8 +21,6 @@ from lms.djangoapps.courseware.block_render import (
     make_track_function,
 )
 from common.djangoapps.student.tests.factories import AdminFactory, StaffFactory
-from xblock.runtime import DictKeyValueStore, KvsFieldData
-from xblock.test.tools import TestRuntime
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,7 +19,8 @@ from lms.djangoapps.courseware.block_render import (
     make_track_function,
 )
 from common.djangoapps.student.tests.factories import AdminFactory, StaffFactory
-
+from xblock.runtime import DictKeyValueStore, KvsFieldData
+from xblock.test.tools import TestRuntime
 
 BASE_DIR = os.path.dirname(os.path.realpath(__file__))
 
@@ -36,8 +37,10 @@ def make_scope_ids(usage_key):
         xblock.fields.ScopeIds: A ScopeIds object for the block for usage_key
     """
     block_type = 'fake'
+    runtime = TestRuntime(services={'field-data': KvsFieldData(kvs=DictKeyValueStore())})
+    def_id = runtime.id_generator.create_definition(block_type)
     return ScopeIds(
-        'user', block_type, "definition_id", usage_key
+        'user', block_type, def_id, usage_key
     )
 
 


### PR DESCRIPTION
#### What are the relevant tickets?
https://github.com/mitodl/rapid-response-xblock/issues/142

#### What's this PR do?
This PR fixes the integration tests which were broken after the removal of old Mongo support for parent child relationship
Our tests started to break after the https://github.com/openedx/edx-platform/pull/31134 was merged giving us an ScopeError
This PR changes the tests to use the new SplitMongo modulestore

See more information in the relevant issue ticket

#### How should this be manually tested?

- Clone the https://github.com/mitodl/rapid-response-xblock/commit/31bf3b89abbd730cd458a3323d259f6ae89c975b in the `src` folder of your devstack work directory
- Open the terminal and run `./run_devstack_integration_tests.sh `
- All the tests should pass

